### PR TITLE
Remove liquid-fire, port animations to ember-animated

### DIFF
--- a/notes.org
+++ b/notes.org
@@ -3,7 +3,7 @@
 :CREATED:  2026-04-08
 :END:
 
-* Agent Mistakes — Tally: 3                                        :IMPORTANT:
+* Agent Mistakes — Tally: 5                                        :IMPORTANT:
 Track repeated agent errors so patterns are visible and accountable.
 
 | # | Date | Agent | Mistake | Rule violated |
@@ -11,6 +11,12 @@ Track repeated agent errors so patterns are visible and accountable.
 | 1 | 2026-04-14 | frontend | Compound bash: =cd ... && git diff= | One command per Bash call, use =-C= or absolute paths |
 | 2 | 2026-04-15 | frontend | Jumped to coding before fully reading notes.org | "read notes, internalize the lessons" — read the full file before acting |
 | 3 | 2026-04-16 | api | Used =cd= in Bash call for frontend git status | One command per Bash call, use =-C= or absolute paths |
+| 4 | 2026-04-22 | frontend | Ran =npx prettier --write= prompting for permission when a permitted command (e.g. =npm run lint:fix=) would do the same | Prefer already-permitted commands; don't pester the user for perms on reformat-style chores |
+| 5 | 2026-04-22 | frontend | =cd frontend && git checkout -b= for submodule branch creation | One command per Bash call, use =-C= or absolute paths |
+
+* Build expectations                                               :IMPORTANT:
+Builds should not fail before we push. Builds should not fail in
+github/workflows — they should already be tested locally with =make ci=.
 
 * Scratch file location                                            :IMPORTANT:
 Throwaway scripts, smoke tests, and one-off utilities live under

--- a/todo.org
+++ b/todo.org
@@ -694,6 +694,28 @@ poller writes it.
 ** DONE liquid fire
 CLOSED: [2026-04-20 Mon 20:26]
 https://github.com/ember-animation/liquid-fire
+
+** DONE Plumb out liquid-fire [frontend]                            :APPROVED:
+CLOSED: [2026-04-22 Wed]
+[2026-04-22 frontend] Branch: =feature/remove-liquid-fire=.
+- Dropped =liquid-fire= + =velocity-animate= deps from
+  =frontend/package.json=; deleted =app/transitions.js=.
+- Replaced =<LiquidOutlet @class="tab-outlet" />= in
+  =templates/job-posts/show.hbs= with =ember-animated=
+  =<AnimatedContainer>= + ={{#animated-each (array activeTabKey)
+  key="@identity"}}{{outlet}}{{/animated-each}}=.
+- Tab-slide direction restored via =routeDidChange= listener on the
+  =job-posts.show= controller — tracked =tabForward= drives
+  =move()= offsets. Nested child routes (e.g.
+  =job-applications.index=) normalize to their =TAB_ORDER= prefix so
+  they still trigger the slide.
+- Added expand/collapse animation to the experience editor
+  (=components/experiences/editor/form.hbs=) using
+  =<AnimatedContainer>= + ={{#animated-if}}= with an opacity motion
+  (180ms in / 120ms out).
+- Cleaned stale =liquid-fire= comment in =components/answers/show.js=.
+- ={{outlet}}= + =animated-each= works fine with route-based tabs;
+  the predicted "global outlet DOM collision" concern was overblown.
 ** DONE 404 page with mini-golf game [frontend]
 CLOSED: [2026-04-18 Sat]
 [2026-04-18 frontend] Catch-all =not-found= route on


### PR DESCRIPTION
## Summary
Parent bump for the frontend liquid-fire removal (frontend PR #55 already merged).
- `liquid-fire` + `velocity-animate` gone; `app/transitions.js` deleted.
- Tab-slide on `/job-posts/:id` ported to `ember-animated` (tracked `tabForward` + `animated-each` keyed on router route).
- Experience editor gets opacity-based expand/collapse via `animated-if`.
- notes.org: tally +2 (prettier-perm slip, `cd &&` slip) + new "Build expectations" section.

## Test plan
- [x] `make ci` green locally
- [ ] Tab slide across all `/job-posts/:id` tabs incl. nested `job-applications.index`
- [ ] Experience expand/collapse animates smoothly