### PR TITLE
chore: bump ai — obstacle agent page_structure + glimmer click fix

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -307,6 +307,28 @@ cold loads still get the skeleton. Frontend PR #88.
 CLOSED: [2026-04-29 Wed]
 =Resume.to_export_context= had a stray =Tool/Platform= → =Tools/Platforms=
 fix. API PR #73.
+** SHIPPED LinkedIn obstacle-agent: page_structure plumbing + glimmer-stable click bypass [ai]
+CLOSED: [2026-04-29 Wed]
+Three intertwined bugs unblocking LinkedIn =/uas/login= account-chooser
+clears (scrape 200 was the canary):
+- =ObstacleAgent= now consumes =ScrapeProfile.page_structure= (where
+  the actual obstacle-clearing selector list lives) — previously it
+  only read =interaction_hints=, which is unset on the LinkedIn
+  profile, so the LLM was flying blind.
+- =_detect_login_wall= short-circuited =word_count >= 200 → False=
+  BEFORE strong-signal checks, so long login walls slipped the gate
+  entirely and let the parser hallucinate "job posts" from welcome
+  copy. Strong signals now decisive at any length; weak-signal
+  threshold still gated on word count. Per-host strong phrases live
+  on =ScrapeProfile.css_selectors.login_wall_signals=.
+- Both =_try_rememberme_reauth= and =ObstacleAgent.try_click= were
+  failing with =waiting for element to be stable= because LinkedIn
+  wraps the chooser in =<div class="glimmer">= (perpetual
+  skeleton-load animation). Now =click(timeout=5_000, force=True)=
+  bypasses Playwright's actionability gate.
+Touched: =agents/obstacle_agent.py=, =lib/scrape_graph/nodes_obstacle.py=,
+=mcp_servers/browser_server.py=. Verified end-to-end on prod scrape 200.
+AI PR #33.
 ** PROJ Feature sorting tables
 * Inbox
 ** TODO system light dark


### PR DESCRIPTION
## Summary

Bumps `ai/` submodule to pick up [ai PR #33](https://github.com/overcast-software/career_caddy_ai/pull/33). Three intertwined fixes that unblocked LinkedIn `/uas/login` account-chooser scrapes (scrape 200 was the canary).

| change | submodule | what |
|---|---|---|
| `ObstacleAgent` reads `page_structure` | ai | consumes the per-host selector list that's been on the LinkedIn profile all along but never reached the LLM. `interaction_hints` was the only thing previously plumbed and it's unset on LinkedIn. |
| `_detect_login_wall` strong-signal gate | ai | strong signals (Cloudflare bot-checks, `sign in to discover`, etc.) now decisive at any page length. The `word_count >= 200 → False` short-circuit fired before strong checks, letting long login walls (LinkedIn /uas/login is >200 words) slip past entirely so the parser hallucinated "job posts" from welcome copy. Per-host strong phrases now live on `ScrapeProfile.css_selectors.login_wall_signals`. |
| `click(force=True)` for chooser tiles | ai | both `_try_rememberme_reauth` and `obstacle_agent.try_click` were timing out on `scroll_into_view_if_needed: waiting for element to be stable`. LinkedIn wraps the chooser in `<div class="glimmer">` (perpetual skeleton-load animation) so Playwright's stability heuristic never resolves. Element is in DOM, visible, clickable — we just have to skip the gate. |

Verified end-to-end on prod scrape 200 after restart.

## Test plan

- [x] ai/ — `uv run pytest tests/` 242 passed (excluding 1 pre-existing flake)
- [x] ai/ — `uv run ruff check` on touched files: clean
- [x] Live test on prod scrape 200 — chooser cleared, posting reached