### PR TITLE
chore: rename ai/ submodule path to agents/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,6 @@
 [submodule "frontend"]
 	path = frontend
 	url = https://github.com/overcast-software/career_caddy_frontend.git
-[submodule "ai"]
-	path = ai
+[submodule "agents"]
+	path = agents
 	url = git@github.com:overcast-software/career_caddy_ai.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Three independently deployable components, each with its own `CLAUDE.md`:
 
 - `frontend/` — Ember.js 6.x SPA (see `frontend/CLAUDE.md`)
 - `api/` — Django REST Framework backend (see `api/CLAUDE.md` — not yet created)
-- `ai/` — Pydantic-AI agents + MCP servers (see `ai/CLAUDE.md`)
+- `agents/` — Pydantic-AI agents + MCP servers (see `agents/CLAUDE.md`)
 
 ## Getting Started (Full Local Dev)
 
@@ -31,8 +31,8 @@ docker compose up --build
 **With browser MCP server** (for Claude Desktop / MCP clients):
 
 ```bash
-# Ensure ai/secrets.yml exists (job site credentials for browser automation)
-cp ai/secrets.yml.example ai/secrets.yml
+# Ensure agents/secrets.yml exists (job site credentials for browser automation)
+cp agents/secrets.yml.example agents/secrets.yml
 
 make up-ai
 # Browser MCP:  http://localhost:3004/sse
@@ -92,14 +92,14 @@ frontend (Ember SPA :4200)
     ↕ JSON:API  Authorization: Bearer <jwt>
 api (Django + SQLAlchemy + PostgreSQL :8000)
     ↑ REST API calls (CC_API_TOKEN API key)
-ai (Pydantic-AI agents + MCP servers)
+agents (Pydantic-AI agents + MCP servers)
 ```
 
 The **frontend** is a JSON:API client. The `application` adapter injects JWT auth headers and handles 401 → token refresh → retry automatically.
 
 The **API** uses Django ORM for all models. Startup requires only `manage.py migrate`.
 
-The **AI layer** runs locally. Agents chain MCP servers as tool providers. Email→JobPost orchestration now lives in the sibling repo `~/Projects/career_caddy_automation`, which consumes tools from `mcp.careercaddy.online/mcp`; this repo's `ai/` only ships the local browser/scrape agents and the hold-poller. The AI layer authenticates to the API using a long-lived API key (`CC_API_TOKEN`), not a JWT.
+The **AI layer** runs locally. Agents chain MCP servers as tool providers. Email→JobPost orchestration now lives in the sibling repo `~/Projects/career_caddy_automation`, which consumes tools from `mcp.careercaddy.online/mcp`; this repo's `agents/` only ships the local browser/scrape agents and the hold-poller. The AI layer authenticates to the API using a long-lived API key (`CC_API_TOKEN`), not a JWT.
 
 ## Cross-Component Contracts
 
@@ -163,7 +163,7 @@ dagger -m ./dagger call deploy --ssh-key=file:~/.ssh/id_ed25519 --host=<vps> --a
 feature/*  →  main
 ```
 
-No `develop` branch in practice — feature branches are cut from `main` and PR'd back to `main`. Submodules (`api/`, `frontend/`, `ai/`) commit first; the parent repo bumps the submodule pointers after.
+No `develop` branch in practice — feature branches are cut from `main` and PR'd back to `main`. Submodules (`api/`, `frontend/`, `agents/`) commit first; the parent repo bumps the submodule pointers after.
 
 **Daily workflow:**
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -89,13 +89,13 @@ ci-ai: ## Build the slim AI Docker image via Dagger (no camoufox — production 
 # Requires: CC_API_TOKEN and OPENAI_API_KEY set in .env or environment
 
 pipeline-url: ## Scrape a single job URL  (usage: make pipeline-url URL=https://...)
-	cd ai && uv run caddy-pipeline --url $(URL)
+	cd agents && uv run caddy-pipeline --url $(URL)
 
 poller: ## Poll for hold scrapes against prod (pass ARGS="--engine chrome --headless")
-	cd ai && uv run caddy-poller $(ARGS)
+	cd agents && uv run caddy-poller $(ARGS)
 
 poller-local: ## Poll for hold scrapes against local dev (localhost:8000; set CC_API_TOKEN_LOCAL to override prod token)
-	cd ai && CC_API_BASE_URL=http://localhost:8000 CC_API_TOKEN=$${CC_API_TOKEN_LOCAL:-$$CC_API_TOKEN} uv run caddy-poller $(ARGS)
+	cd agents && CC_API_BASE_URL=http://localhost:8000 CC_API_TOKEN=$${CC_API_TOKEN_LOCAL:-$$CC_API_TOKEN} uv run caddy-poller $(ARGS)
 
 # ── Bootstrap ──────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ every resource.
 |-----------|-------|------|
 | `frontend/` | Ember.js 6.x SPA | User interface, JSON:API client |
 | `api/` | Django REST Framework | Data layer, extraction, AI orchestration |
-| `ai/` | Pydantic-AI + MCP servers | Browser automation, email pipeline, agents |
-| Chat service | Starlette SSE (in `ai/`) | Streaming AI chat with page-context awareness |
-| MCP server | FastMCP (in `ai/`) | Public read-only career data tools for MCP clients |
-| Hold-poller | Standalone worker (in `ai/`) | Polls API for queued scrapes, runs browser locally |
+| `agents/` | Pydantic-AI + MCP servers | Browser automation, email pipeline, agents |
+| Chat service | Starlette SSE (in `agents/`) | Streaming AI chat with page-context awareness |
+| MCP server | FastMCP (in `agents/`) | Public read-only career data tools for MCP clients |
+| Hold-poller | Standalone worker (in `agents/`) | Polls API for queued scrapes, runs browser locally |
 
 **Why Ember.js?** The app has complex nested routes (job post → application → question →
 answer) and many inter-resource relationships. Ember's conventions for nested routing, the
@@ -41,7 +41,7 @@ them as MCP servers makes them composable with any MCP client (Claude Desktop, e
 
 ## Key Features
 
-- **Tiered extraction** — Domain profiles learn from past scrapes, auto-selecting from CSS-only ($0) to full LLM ($0.10). See `ai/CLAUDE.md` for model config.
+- **Tiered extraction** — Domain profiles learn from past scrapes, auto-selecting from CSS-only ($0) to full LLM ($0.10). See `agents/CLAUDE.md` for model config.
 - **Hold-poller** — Headless browser worker that runs on a desktop or Raspberry Pi, scraping jobs the VPS cannot handle. The VPS queues work; the poller executes it.
 - **AI chat** — SSE streaming assistant aware of your current page context, with elicitation buttons for guided workflows.
 - **MCP integration** — Public career data tools exposable to any MCP client (Claude Desktop, Cursor, etc.).
@@ -145,7 +145,7 @@ The hold-poller is a standalone Python process that bridges the gap between the 
 
 # 2. Run it
 make poller
-# Or directly: cd ai && uv run caddy-poller
+# Or directly: cd agents && uv run caddy-poller
 ```
 
 The poller polls the API every 30 seconds (configurable via `HOLD_POLL_INTERVAL`). It backs off exponentially when there's no work, and resets on success.

--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -14,7 +14,7 @@ Usage (from repo root):
 In GitHub Actions, call via: dagger -m ./dagger call publish ...
 
 NOTE: Directory parameters use DefaultPath relative to the dagger/ module root.
-      Defaults: ../api → api/, ../frontend → frontend/, ../ai → ai/
+      Defaults: ../api → api/, ../frontend → frontend/, ../agents → agents/
       Override: --src=./path/to/dir (or --api-src=, --frontend-src=, etc.)
 """
 
@@ -150,7 +150,7 @@ class CareerCaddy:
     @function
     async def build_ai(
         self,
-        src: Annotated[dagger.Directory, DefaultPath("../ai")],
+        src: Annotated[dagger.Directory, DefaultPath("../agents")],
     ) -> dagger.Container:
         """Build the AI agent image (Python 3.13, no Camoufox).
 
@@ -187,7 +187,7 @@ class CareerCaddy:
     @function
     async def test_ai(
         self,
-        src: Annotated[dagger.Directory, DefaultPath("../ai")],
+        src: Annotated[dagger.Directory, DefaultPath("../agents")],
     ) -> dagger.Container:
         """Run AI test suite (toolsets, api_tools, public_server security)."""
         src = (
@@ -225,7 +225,7 @@ class CareerCaddy:
         registry_token: Secret,
         api_src: Annotated[dagger.Directory, DefaultPath("../api")],
         frontend_src: Annotated[dagger.Directory, DefaultPath("../frontend")],
-        ai_src: Annotated[dagger.Directory, DefaultPath("../ai")],
+        ai_src: Annotated[dagger.Directory, DefaultPath("../agents")],
         org: str = "overcast-software",
         tag: str = "latest",
         registry_username: str = "",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,13 +90,13 @@ services:
 
   chat:
     build:
-      context: ./ai
+      context: ./agents
       args:
         INSTALL_CAMOUFOX: "false"
     working_dir: /app
     command: sh -c "uv sync && uv run caddy-chat"
     volumes:
-      - ./ai:/app
+      - ./agents:/app
       - chat_venv:/app/.venv
     environment:
       CC_API_BASE_URL: "http://api:8000"
@@ -116,7 +116,7 @@ services:
 
   browser-mcp:
     build:
-      context: ./ai
+      context: ./agents
       args:
         INSTALL_CAMOUFOX: "${INSTALL_CAMOUFOX:-true}"
     working_dir: /app
@@ -130,7 +130,7 @@ services:
       CAMOUFOX_DATA_DIR: /opt/camoufox
       SCREENSHOT_DIR: /app/screenshots
     volumes:
-      - ./ai/secrets.yml:/app/secrets.yml:ro
+      - ./agents/secrets.yml:/app/secrets.yml:ro
 
 
 volumes:

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -161,11 +161,11 @@ if $CHECK_POLLER || env_set CC_API_TOKEN 2>/dev/null; then
     fail "uv is not installed — see https://docs.astral.sh/uv/"
   fi
 
-  if [[ -d "$PROJECT_ROOT/ai" ]]; then
-    if (cd "$PROJECT_ROOT/ai" && uv run python -c "import camoufox" 2>/dev/null); then
+  if [[ -d "$PROJECT_ROOT/agents" ]]; then
+    if (cd "$PROJECT_ROOT/agents" && uv run python -c "import camoufox" 2>/dev/null); then
       pass "Camoufox is importable"
     else
-      fail "Camoufox not available — run: cd ai && uv sync && python -m camoufox fetch"
+      fail "Camoufox not available — run: cd agents && uv sync && python -m camoufox fetch"
     fi
   fi
 
@@ -189,13 +189,13 @@ if $CHECK_POLLER || env_set CC_API_TOKEN 2>/dev/null; then
 fi
 
 # ── Group 6: Browser Automation ──────────────────────────────────────────
-if [[ -d "$PROJECT_ROOT/ai" ]]; then
+if [[ -d "$PROJECT_ROOT/agents" ]]; then
   header "Browser Automation"
 
-  if [[ -f "$PROJECT_ROOT/ai/secrets.yml" ]]; then
-    pass "ai/secrets.yml exists"
+  if [[ -f "$PROJECT_ROOT/agents/secrets.yml" ]]; then
+    pass "agents/secrets.yml exists"
   else
-    warn "ai/secrets.yml missing — needed for login automation (cp ai/secrets.yml.example ai/secrets.yml)"
+    warn "agents/secrets.yml missing — needed for login automation (cp agents/secrets.yml.example agents/secrets.yml)"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Renames the parent's reference to the AI/agents submodule from `ai/` to `agents/`. Submodule repo (`career_caddy_ai`) and GHCR image name are unchanged.
- Phase A of the architecture re-org plan. Internal restructure of the submodule (lifting `mcp/`, `browser/`, `scrape_graph/`, `pollers/`, `tools/` to top-level peers) lands in a separate PR.

## Files

- `.gitmodules` — section + path rename.
- `Makefile` — 3× `cd ai` → `cd agents`.
- `docker-compose.yml` — chat/browser-mcp build context + bind mounts + secrets.yml mount.
- `dagger/src/career_caddy_pipeline.py` — `DefaultPath("../ai")` → `DefaultPath("../agents")` (×3) + docstring.
- `scripts/doctor.sh` — 6 `\$PROJECT_ROOT/ai` references.
- `README.md`, `CLAUDE.md` — component table + prose.

## Test plan

- [x] `make ci` (build-api + build-frontend) green
- [x] `make ci-ai` (Dagger build of agents image at the new path) green — 56.2s fresh build
- [x] `bash scripts/doctor.sh` → 19 passed, 1 warning, 0 failed
- [x] `docker compose config -q` valid
- [x] `\bai/` grep across Makefile/compose/dagger/scripts/README/CLAUDE/.gitmodules → only `claude.ai/code` URL remains (unrelated)