### PR TITLE
chore: point agents submodule at career_caddy_agents repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/overcast-software/career_caddy_frontend.git
 [submodule "agents"]
 	path = agents
-	url = git@github.com:overcast-software/career_caddy_ai.git
+	url = git@github.com:overcast-software/career_caddy_agents.git


### PR DESCRIPTION
## Summary

Submodule `agents/` now tracks `github.com/overcast-software/career_caddy_agents` instead of `career_caddy_ai`, matching the path-rename Phase A landed.

History was force-pushed to the new repo (it only contained a stock initial commit). Old repo keeps the GHCR image linkage — `ghcr.io/overcast-software/career_caddy_ai` is intentionally unchanged so prod pulls don't break.

## Test plan

- [x] `git submodule sync agents` updates `.git/config` cleanly
- [x] `git remote -v` in `agents/` shows the new URL
- [x] CI image still publishes to the unchanged GHCR path