### PR TITLE
chore: switch api + frontend submodule remotes to SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "api"]
 	path = api
-	url = https://github.com/overcast-software/career_caddy_api.git
+	url = git@github.com:overcast-software/career_caddy_api.git
 [submodule "frontend"]
 	path = frontend
-	url = https://github.com/overcast-software/career_caddy_frontend.git
+	url = git@github.com:overcast-software/career_caddy_frontend.git
 [submodule "agents"]
 	path = agents
 	url = git@github.com:overcast-software/career_caddy_agents.git


### PR DESCRIPTION
## Summary

`.gitmodules` parity. All three submodules now over SSH:

- `api` HTTPS → SSH
- `frontend` HTTPS → SSH
- `agents` already SSH (since the rename to `career_caddy_agents`)

The HTTPS pushes from a sandboxed shell hung silently on `git-gui--askpass` during Phase B; SSH parity uses ssh-agent and just works.

## Test plan

- [x] `git -C api ls-remote --heads origin` returns refs over SSH
- [x] `git -C frontend ls-remote --heads origin` returns refs over SSH
- [x] No content change inside submodules