### PR TITLE
feat: hover date shows created datetime in job-posts list

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -234,6 +234,13 @@ implements a =loading= action that returns =true= (suppresses the substate)
 when =transition.from.name === routeName= — i.e. in-route refreshes only;
 cold loads still get the skeleton. Frontend PR #88.
 * Inbox
+** DONE job-posts list: hover date shows created datetime :frontend:
+CLOSED: [2026-05-02]
+=frontend/app/components/job-posts/list.hbs= — wrapped posted-date cell in
+=<span title="created: ...">= using =createdAt= so hovering reveals the exact
+ingestion timestamp. Lets the user confirm email-sourced posts arrived at the
+expected time without opening the record. Frontend PR #103.
+
 ** DONE Retry scrape redirects to new child scrape :frontend:
 CLOSED: [2026-05-02]
 =job-posts/show/scrapes/show.js= controller: after =redo= POST, poll


### PR DESCRIPTION
Bumps frontend to PR #103. Hovering the date column in `/job-posts` shows `created: MMM D, YYYY h:mm A` (always off `createdAt`) so exact ingestion time of email-sourced posts is visible without opening the record.

| repo | PR | change |
|------|----|--------|
| frontend | #103 | `list.hbs` — span title with createdAt datetime |
| parent | — | bump frontend pointer, todo.org |