### PR TITLE
chore: bump api — DescriptionArbiter Layer 2 (#85)

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -234,7 +234,452 @@ implements a =loading= action that returns =true= (suppresses the substate)
 when =transition.from.name === routeName= — i.e. in-route refreshes only;
 cold loads still get the skeleton. Frontend PR #88.
 * Inbox
-** PROJ Description merge + arbiter [PR A: Layer 1, PR B: Layer 2] :api:ai:
+** TODO Extension from-text: synchronous extraction + paste-fallback for source==extension :api:bug:
+:PROPERTIES:
+:CREATED:  [2026-05-02]
+:END:
+*Trigger:* scrape 273 (manually flipped to =failed= 2026-05-02). Extension-ingested
+scrape from =https://careers.dat.com/jobs/?gh_jid=5741667004&gh_src=fd81f4a54us=
+sat in =status=extracting= for >4 minutes with no progress and no recovery.
+Logfire showed zero =parse_scrape= / =process_evaluation= / Tier1Mini spans
+system-wide for the prior 24h — the =parse_scrape= daemon thread either died
+silently after flipping status to =extracting= (line 756 of
+=job_post_extractor.py=) or never executed. The user (plugin clicker) was
+sitting at their machine waiting for a result that never came.
+
+*Why this fix shape:* the extension is reliable in 99% of cases — the
+captured =job_content= is usable. We don't need an async daemon-thread
+gambit for plugin scrapes: the request is already a synchronous user
+action, and the LLM extraction call is fast (~2-10s, no browser fetch).
+Block the request. Eliminate the stuck-extracting class entirely for
+this code path.
+
+*** Files
+
+- =api/job_hunting/api/views/scrapes.py= — =from_text= action (line 582-692).
+  =parse_scrape= is currently called at line 686 with default =sync=False=
+  (which spawns a daemon thread).
+- =api/job_hunting/lib/parsers/job_post_extractor.py= — =process_evaluation=
+  (line 211+); paste fallback at lines 242-249.
+
+*** Change A: =from_text= calls =parse_scrape(..., sync=True)=
+
+In =api/job_hunting/api/views/scrapes.py=, line 686:
+
+#+begin_src python
+# BEFORE
+parse_scrape(scrape.id, user_id=request.user.id)
+
+# AFTER
+parse_scrape(scrape.id, user_id=request.user.id, sync=True)
+#+end_src
+
+The endpoint now blocks until =parse_scrape= reaches a terminal status
+(=completed= or =failed=). Status flow becomes:
+=pending= → =extracting= → =updating_profile= → =completed= | =failed=,
+all inside the single HTTP request.
+
+Caveat: typical =from_text= LLM call is 2-10s. Long enough that the
+endpoint should return =200/202= with the terminal status reflected in
+the response body so the popup can show "added ✓" or "failed" immediately
+instead of polling. The current 202 response is fine; the popup already
+hands off to a background poller (=background.js= =pollScrapeOnce=). With
+sync=True the scrape is already terminal when the response comes back,
+so the first poll gets the result immediately. No popup change required.
+
+*** Change B: extend paste fallback in =process_evaluation=
+
+In =api/job_hunting/lib/parsers/job_post_extractor.py=, lines 242-249:
+
+#+begin_src python
+# BEFORE
+effective_description = validated_data.description
+if (
+    not effective_description
+    and getattr(scrape, "source", None) == "paste"
+):
+    fallback = (scrape.job_content or "").strip()
+    if fallback:
+        effective_description = fallback
+
+# AFTER
+effective_description = validated_data.description
+if (
+    not effective_description
+    and getattr(scrape, "source", None) in ("paste", "extension")
+):
+    fallback = (scrape.job_content or "").strip()
+    if fallback:
+        effective_description = fallback
+#+end_src
+
+Reasoning: when the LLM omits a description on an =extension= scrape,
+the captured =job_content= IS the user's intended description (modulo
+nav/footer chrome). Letting it pass through is graceful degradation
+when the LLM is broken/unavailable. Layer 1 stub-upgrade gate
+(=STUB_MIN_WORDS=60=, just shipped in api PR #84) protects against
+chrome-only fallbacks polluting good existing JPs — a thin fallback
+won't overwrite a populated description.
+
+Risk: an extension capture that's mostly chrome (e.g. greenhouse-
+iframed pages where iframe text doesn't reach =document.body.innerText=)
+will populate the description with nav/footer noise on a fresh-create.
+Acceptable trade because: (a) better than silent loss, (b) Layer 1
+prevents replacement of good descriptions, (c) the iframe class is
+addressed by the separate extension =allFrames= todo below.
+
+*** Tests
+
+Add to =api/job_hunting/tests/test_scrape_from_text.py=:
+
+#+begin_src python
+class TestFromTextSyncExtraction(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="t", password="p")
+        self.client.force_authenticate(user=self.user)
+
+    @patch("job_hunting.lib.parsers.job_post_extractor._build_agent_for_model")
+    def test_extension_source_blocks_until_terminal(self, mock_agent):
+        # Mock LLM to return a valid ParsedJobData
+        mock_agent.return_value.run_sync.return_value = ...
+
+        resp = self.client.post(
+            "/api/v1/scrapes/from-text/",
+            {"text": "..." * 100, "link": "https://example.com/job/1",
+             "source": "extension"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 202)
+        scrape_id = resp.data["data"]["id"]
+        scrape = Scrape.objects.get(pk=scrape_id)
+        # MUST be terminal — sync=True guarantees no leftover extracting state
+        self.assertIn(scrape.status, ("completed", "failed"))
+#+end_src
+
+Add to =api/job_hunting/tests/test_job_post_extractor.py= near the
+existing =test_paste_scrape_falls_back_to_job_content_when_llm_omits_description=:
+
+#+begin_src python
+@patch("job_hunting.lib.parsers.job_post_extractor.JobPostExtractor.analyze_with_ai")
+def test_extension_scrape_falls_back_to_job_content_when_llm_omits_description(
+    self, mock_analyze
+):
+    # LLM returns valid data but with description=None
+    mock_analyze.return_value = ParsedJobData(
+        title="Engineer", company_name="Acme", description=None
+    )
+    raw_text = "Real description text " * 50  # ≥ STUB_MIN_WORDS
+    scrape = Scrape.objects.create(
+        url="https://example.com/job/1",
+        job_content=raw_text,
+        status="pending",
+        created_by=self.user,
+        source="extension",
+    )
+    parse_scrape(scrape.id, user_id=self.user.id, sync=True)
+
+    job = JobPost.objects.get(link="https://example.com/job/1")
+    self.assertIn("Real description text", job.description)
+#+end_src
+
+*** Acceptance criteria
+1. =from-text= endpoint never returns while a scrape is in =extracting=.
+2. Extension scrape with LLM omitting description ends up with =job_content=
+   stored as JobPost.description (not lost).
+3. =make ci= green.
+4. Smoke test on prod: submit any plugin scrape; confirm it reaches a
+   terminal status before the popup's first poll.
+
+*** Out of scope
+- Changing the popup-side handoff to background.js (no change needed).
+- Sweeper for =extracting > N min= rows from OTHER code paths (re-extract,
+  hold-poller). Tracked separately under "Extracting-state safety net" todo.
+- Iframe-walking in the extension capture (separate todo).
+
+** TODO Extracting-state safety net: try/finally + sweeper :api:bug:
+:PROPERTIES:
+:CREATED:  [2026-05-02]
+:END:
+*Trigger:* scrape 273 stuck at =extracting= even though =parse_scrape='s
+=_run= function (=api/job_hunting/lib/parsers/job_post_extractor.py:733-795=)
+already wraps =parser.parse()= in try/except (line 760-763). The =extracting=
+status was written at line 756, then the daemon thread died before reaching
+=updating_profile= (line 765) or the success/fail status flip (lines 776-795).
+
+Most likely root causes (any of them is possible):
+- Daemon thread killed by container restart (deploy churn) between line 756
+  and line 765/793.
+- Uncaught exception in pre-parse setup (lines 738-754: DB lookups, user
+  resolution).
+- Uncaught exception in =_log_scrape_status= itself.
+- OOM kill of the api container while the LLM call was in flight.
+
+Even after the from-text =sync=True= fix above, =parse_scrape= is still
+called from other paths that DO use daemon threads:
+- =api/job_hunting/api/views/jobs.py= =reextract= action (line 696)
+- =api/job_hunting/api/views/scrapes.py= =parse= action (line 540, =_reparse_force=)
+- Hold-poller's =partial_update= → =_maybe_trigger_extraction= →
+  =_reparse_force= path (=scrapes.py:540=)
+
+These need a safety net.
+
+*** Change A: try/finally around =_run= so terminal status is guaranteed
+
+In =api/job_hunting/lib/parsers/job_post_extractor.py=, =parse_scrape._run=
+(line 733):
+
+#+begin_src python
+def _run():
+    from job_hunting.models.scrape import Scrape as ScrapeModel
+    from job_hunting.lib.scraper import _log_scrape_status
+    from django.contrib.auth import get_user_model
+
+    reached_terminal = False
+    try:
+        scrape = ScrapeModel.objects.filter(pk=scrape_id).first()
+        if not scrape:
+            logger.warning("parse_scrape: scrape_id=%s not found", scrape_id)
+            reached_terminal = True  # nothing to flip
+            return
+        # ... existing body unchanged through the success/failure status flip ...
+        # Inside the existing branches, set reached_terminal = True after each
+        # _log_scrape_status("completed", ...) and _log_scrape_status("failed", ...)
+    except Exception:
+        logger.exception("parse_scrape: unhandled in _run scrape_id=%s", scrape_id)
+    finally:
+        if not reached_terminal:
+            # Guarantee the scrape leaves `extracting` no matter what.
+            try:
+                _log_scrape_status(
+                    scrape_id, "failed",
+                    note="parse_scrape died before terminal — see api logs",
+                )
+            except Exception:
+                logger.exception(
+                    "parse_scrape: failed to flip stuck scrape_id=%s to failed",
+                    scrape_id,
+                )
+#+end_src
+
+Set =reached_terminal = True= at lines 790 (=completed=) and 793 (=failed=)
+inside the existing branches.
+
+*** Change B: management command for stuck-extracting sweep
+
+New file =api/job_hunting/management/commands/sweep_stuck_extracting.py=:
+
+#+begin_src python
+from datetime import timedelta
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from job_hunting.models import Scrape
+from job_hunting.lib.scraper import _log_scrape_status
+
+
+class Command(BaseCommand):
+    help = "Flip Scrapes stuck in extracting/updating_profile to failed."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--min-age-minutes", type=int, default=15)
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, min_age_minutes, dry_run, **opts):
+        cutoff = timezone.now() - timedelta(minutes=min_age_minutes)
+        stuck = Scrape.objects.filter(
+            status__in=["extracting", "updating_profile"],
+            updated_at__lt=cutoff,  # or use the latest_status timestamp
+        )
+        for s in stuck:
+            self.stdout.write(
+                f"scrape={s.id} status={s.status} updated_at={s.updated_at}"
+            )
+            if not dry_run:
+                _log_scrape_status(
+                    s.id, "failed",
+                    note=f"swept: stuck in {s.status} > {min_age_minutes}m",
+                )
+        self.stdout.write(f"swept {stuck.count()} stuck scrapes")
+#+end_src
+
+Wire as cron via the existing scheduling pattern (or invoke from
+=make sweep-stuck= for now; later cron is a separate ticket).
+
+*** Tests
+
+=api/job_hunting/tests/test_parse_scrape_safety.py= (new):
+
+#+begin_src python
+class TestParseScrapeSafetyNet(TestCase):
+    def test_unhandled_exception_flips_to_failed(self):
+        scrape = Scrape.objects.create(
+            url="https://example.com/x", job_content="x" * 200,
+            status="pending", created_by=self.user, source="extension",
+        )
+        with patch(
+            "job_hunting.lib.parsers.job_post_extractor.JobPostExtractor.parse"
+        ) as p:
+            p.side_effect = RuntimeError("simulated daemon-thread death")
+            parse_scrape(scrape.id, user_id=self.user.id, sync=True)
+        scrape.refresh_from_db()
+        # Even with an unhandled exception, scrape MUST reach terminal.
+        self.assertEqual(scrape.status, "failed")
+
+    def test_pre_parse_db_failure_flips_to_failed(self):
+        # Simulate ScrapeModel.objects.filter raising
+        with patch("job_hunting.models.scrape.Scrape.objects") as mgr:
+            mgr.filter.side_effect = OperationalError("db down")
+            # Should not raise, should not loop forever
+            parse_scrape(99999, user_id=self.user.id, sync=True)
+        # No assertion on status — scrape doesn't exist in this test —
+        # but the call must return without error.
+
+class TestSweepStuckExtractingCommand(TestCase):
+    def test_sweeps_old_extracting_rows(self):
+        old = Scrape.objects.create(
+            url="https://example.com/old", status="extracting",
+            created_by=self.user, source="extension",
+        )
+        Scrape.objects.filter(pk=old.id).update(
+            updated_at=timezone.now() - timedelta(minutes=20)
+        )
+        recent = Scrape.objects.create(
+            url="https://example.com/new", status="extracting",
+            created_by=self.user, source="extension",
+        )
+        call_command("sweep_stuck_extracting", "--min-age-minutes=15")
+        old.refresh_from_db(); recent.refresh_from_db()
+        self.assertEqual(old.status, "failed")
+        self.assertEqual(recent.status, "extracting")
+#+end_src
+
+*** Acceptance criteria
+1. Any =parse_scrape= invocation that reaches the daemon thread leaves
+   the scrape in a terminal status (=completed= or =failed=), even on
+   uncaught exception or container restart mid-flight.
+2. =python manage.py sweep_stuck_extracting --min-age-minutes=15= flips
+   stuck rows; =--dry-run= reports without flipping.
+3. =make ci= green.
+
+*** Out of scope
+- Cron schedule for =sweep_stuck_extracting= (file separately if you want
+  it on a timer; can also run manually from =make shell-api= for now).
+- Changing the underlying daemon-thread architecture to a real worker
+  queue (Celery / Django-Q). That's a larger refactor.
+
+** TODO Extension allFrames capture for iframe-embedded ATS (greenhouse, dat.com class) :extension:frontend:
+:PROPERTIES:
+:CREATED:  [2026-05-02]
+:END:
+*Trigger:* scrape 273 from =https://careers.dat.com/jobs/?gh_jid=5741667004&gh_src=fd81f4a54us=
+captured page chrome only (~1.1KB of nav/footer + DAT marketing copy, no
+job description body). Root cause: dat.com embeds the actual job description
+inside a greenhouse iframe (host: =boards.greenhouse.io=). The extension's
+=grabPayload= (=frontend/public/extensions/career-caddy-sender/popup.js:336-342=)
+calls =scripting.executeScript= on the active tab without =allFrames=, so
+=document.body.innerText= only sees the parent document — iframe contents
+are invisible.
+
+This pattern is widespread: any ATS that gets embedded into a company's
+own careers page (greenhouse, lever, workday, jobvite) hits the same gap.
+
+*** File
+
+=frontend/public/extensions/career-caddy-sender/popup.js= — =grabPayload=
+(line 336-342). Bump version in =manifest.json= to 0.3.7 and add a
+README.md version-history entry.
+
+*** Change
+
+#+begin_src js
+// BEFORE
+async function grabPayload(tabId) {
+  const results = await api.scripting.executeScript({
+    target: { tabId },
+    func: () => ({ url: location.href, text: document.body.innerText }),
+  });
+  return results && results[0] && results[0].result;
+}
+
+// AFTER
+async function grabPayload(tabId) {
+  const results = await api.scripting.executeScript({
+    target: { tabId, allFrames: true },
+    func: () => ({
+      url: location.href,
+      // Frame metadata so the API side can debug when something goes wrong.
+      frameUrl: location.href,
+      text: document.body ? document.body.innerText : '',
+    }),
+  });
+  if (!results || !results.length) return null;
+  // results[0] is the top frame (per chrome.scripting docs); the rest
+  // are subframes in unspecified order. Top frame's URL is the canonical
+  // link for the scrape.
+  const top = results[0];
+  if (!top || !top.result) return null;
+  // Concatenate every frame's text with a separator the LLM can use to
+  // distinguish chrome from embedded ATS body.
+  const allText = results
+    .map((r) => r && r.result && r.result.text)
+    .filter(Boolean)
+    .join('\n\n--- frame ---\n\n');
+  return { url: top.result.url, text: allText };
+}
+#+end_src
+
+Notes for the implementer:
+- =allFrames: true= requires =host_permissions= covering the iframe origin.
+  Manifest already declares =host_permissions: ["<all_urls>"]= so any
+  cross-origin iframe is reachable.
+- In Firefox MV3 with =<all_urls>= host_permissions and =activeTab=,
+  =allFrames= works for both same- and cross-origin frames.
+- If the page uses a sandboxed iframe (=sandbox= attribute without
+  =allow-same-origin=), =executeScript= will fail for that frame; the
+  result entry will have =frameId= but no =result=. The =filter(Boolean)=
+  drops them silently — acceptable.
+- The =--- frame ---= separator is a hint to the LLM that there are
+  multiple text regions; the prompt doesn't currently mention it but
+  Tier1Mini will benefit from any structural delimiter.
+
+*** Test plan (manual — extension testing is hard to automate)
+
+1. Load extension from =frontend/public/extensions/career-caddy-sender/=
+   in Firefox via =about:debugging= → Load Temporary Add-on.
+2. Navigate to a known greenhouse-embedded page:
+   - =https://careers.dat.com/jobs/?gh_jid=5741667004&gh_src=fd81f4a54us=
+     (the scrape 273 case)
+   - =https://join.com/companies/...= (similar pattern, different ATS)
+3. Click the extension icon → Send.
+4. Open prod/local job-posts list, find the new scrape, confirm
+   =job_content= contains the actual job description body
+   (responsibilities, qualifications) — not just nav + "About DAT".
+5. Confirm =job_content= length > 2KB (sanity check; chrome alone was 1.1KB).
+6. Confirm Tier1Mini extraction yielded a populated =description= on the
+   resulting JobPost.
+
+*** Acceptance criteria
+1. Extension version bumped to 0.3.7 in =manifest.json= + README version-history.
+2. Submitting from a greenhouse-iframed page captures the iframe contents.
+3. Existing single-frame pages (linkedin, indeed direct, paste-only sites)
+   continue to work — no regression.
+4. Same-origin frames still captured correctly (sanity check).
+5. Cross-origin iframe failure (sandboxed iframes) is graceful — popup
+   doesn't crash, just sends what it can.
+
+*** Out of scope
+- Detecting and rewriting tracker URLs (=?gh_jid== → =boards.greenhouse.io/{org}/jobs/{id}=)
+  before navigation. Could be a follow-up if the iframe approach
+  proves flaky, but iframe walking is the cleaner answer.
+- Cleaning chrome out of the captured text in JS. The LLM does that;
+  don't duplicate the work client-side.
+- Updating =~/Sandbox/cc-ext-local/= (it points to localhost:4200 and
+  has its own gecko id; user maintains it manually).
+- Building a new XPI artifact. Once popup.js + manifest.json change,
+  rebuild via:
+  =cd frontend/public/extensions/career-caddy-sender && zip -r ~/Sandbox/career-caddy-sender-0.3.7.xpi . --exclude "*.DS_Store"=
+
+** DONE Description merge + arbiter [PR A: Layer 1, PR B: Layer 2] :api:ai:
+CLOSED: [2026-05-02]
 :PROPERTIES:
 :CREATED:  [2026-05-02]
 :END:
@@ -248,9 +693,12 @@ cold loads still get the skeleton. Frontend PR #88.
   =updated_stub_via_fingerprint= / =duplicate_via_fingerprint=. 4 new tests.
   Promote to SHIPPED after parent Deploy goes green.
 - *PR B — Layer 2*: arbiter LLM picks =keep_existing | use_new | merge=
-  when both descriptions are non-thin and differ materially. Audit row
-  per decision in new =JobPostDescriptionDecision= table. Behind
-  =INGEST_ARBITER_ENABLED= flag.
+  when both descriptions are non-thin and differ materially. Audit row per
+  decision in new =JobPostDescriptionDecision= model (migration 0066). Behind
+  =INGEST_ARBITER_ENABLED= env flag (default on). Cheapness gate: Jaccard
+  5-gram overlap > 0.70 and word-count ratio < 1.5 skips LLM. 17 new tests
+  in =test_description_arbiter.py=. =description_arbiter= added to
+  =_agent_role_specs()=. api PR #N merged [2026-05-02].
 - *Backfill*: =python manage.py rerun_arbiter --since 2026-04-01= as a
   one-shot after PR A+B land.
 


### PR DESCRIPTION
## Summary

- Bumps `api` submodule to `1c909c2` (PR #85: DescriptionArbiter Layer 2)
- Updates `todo.org`: PROJ "Description merge + arbiter" → DONE

## What landed in api #85

| Component | Change |
|-----------|--------|
| `description_arbiter.py` | `DescriptionArbiter` + `maybe_arbitrate_and_persist`; Jaccard cheapness gate skips LLM when descriptions are ≥70% similar |
| `JobPostDescriptionDecision` | New audit model (migration 0066) — persists every arbiter decision |
| `job_post_extractor.py` | `_maybe_apply_arbiter` wired into both `duplicate` branches |
| `text_signals.py` | `jaccard_5gram` utility |
| `admin.py` | `description_arbiter` in `_agent_role_specs` |
| Tests | 17 new tests; full suite 65/65 pass |

## Test plan

- [x] `make ci` green locally (api 65/65, frontend cached ✓)