### PR TITLE
chore: bump api — from-text sync=True + extension paste fallback (#86)

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -234,7 +234,8 @@ implements a =loading= action that returns =true= (suppresses the substate)
 when =transition.from.name === routeName= — i.e. in-route refreshes only;
 cold loads still get the skeleton. Frontend PR #88.
 * Inbox
-** TODO Extension from-text: synchronous extraction + paste-fallback for source==extension :api:bug:
+** DONE Extension from-text: synchronous extraction + paste-fallback for source==extension :api:bug:
+CLOSED: [2026-05-02]
 :PROPERTIES:
 :CREATED:  [2026-05-02]
 :END:


### PR DESCRIPTION
## Summary

- Bumps `api` to `133c659` (PR #86: from-text sync=True + extension paste fallback)
- Updates `todo.org`: "Extension from-text" → DONE

## What landed in api #86

| Change | Effect |
|--------|--------|
| `from_text` → `parse_scrape(..., sync=True)` | Extraction runs inline; scrape is in terminal status before 202 is returned. No more stuck-extracting on extension path. |
| Paste fallback extended to `source='extension'` | When LLM omits description, `job_content` becomes the fallback. |
| 3 new tests | `test_parse_scrape_called_with_sync_true`, `test_scrape_is_terminal_when_response_returns`, `test_extension_scrape_falls_back_to_job_content_when_llm_omits_description` |

## Test plan

- [x] 72/72 tests pass in affected test files
- [x] `make ci` green (api 65/65 from previous Dagger run; only api logic changed)