### PR TITLE
chore: bump frontend — subnav search clear button

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -234,6 +234,17 @@ implements a =loading= action that returns =true= (suppresses the substate)
 when =transition.from.name === routeName= — i.e. in-route refreshes only;
 cold loads still get the skeleton. Frontend PR #88.
 * Inbox
+** DONE Subnav search clear button :frontend:
+CLOSED: [2026-05-03]
+:PROPERTIES:
+:CREATED:  [2026-05-03]
+:END:
+Added an × clear button to =frontend/app/components/menus/subnav-search.hbs/.js=
+that appears only when the input has text. Clicking it clears =inputValue= and
+immediately fires =@onSearch('')= (no debounce). All 7 subnav search bars get
+the button automatically — no call-site changes needed. Wrapper div +
+=.subnav-search-clear= CSS added to =app/styles/app.css=.
+
 ** DONE Extension from-text: synchronous extraction + paste-fallback for source==extension :api:bug:
 CLOSED: [2026-05-02]
 :PROPERTIES:


### PR DESCRIPTION
## Summary

| commit | submodule | what |
|--------|-----------|------|
| 331e706 | frontend | add × clear button to SubnavSearch; all 7 search bars updated |

## Test plan

- [x] `make ci` exit 0 locally