### PR TITLE
fix: job-applications infinite scroll

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -38,7 +38,16 @@ Archive (0)
 - New UI components must use Tailwind utilities following HyperUI patterns. Never custom CSS.
 - Use hyperui, tailwind, and defined color palettes when writing UI html.
 - Submodule scope on entry headings goes in proper org tags (=:frontend:=, =:api:=, =:ai:=, =:bug:=), NOT bracket-suffix annotations like =[frontend]=. Tags stack: =:frontend:bug:=. Don't bulk-rewrite historical =[frontend]= entries.
+** DONE job-applications.index infinite scroll
+CLOSED: [2026-05-04 Mon 16:10]
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-04]
+:END:
+InfinityLoader was wired in the frontend but the API returned no meta/links envelope. Fixed JobApplicationViewSet.list() in api/job_hunting/api/views/jobs.py to emit the same meta + links.next pagination block as JobPostViewSet.
 ** Idea
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-04]
+:END:
 ** Feature
 ** Enhancement
 ** Bug


### PR DESCRIPTION
## Summary

- Bumps `api` submodule to overcast-software/career_caddy_api#92

| submodule | PR | change |
|-----------|-----|--------|
| api | #92 | `JobApplicationViewSet.list()` now emits `meta` + `links.next` so ember-infinity can fetch subsequent pages |

## Test plan

- [x] `make ci` exit 0 (api + frontend lint + tests)