### PR TITLE
chore: bump frontend (jp.show.scores.show route)

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -1,5 +1,5 @@
 #+TITLE: career_caddy todo board
-#+TODO: TODO(t) STRT(s) WAIT(w) | SHIPPED(p) DONE(d)
+#+TODO: TODO(t) STRT(s) WAIT(w) | KILL(k) SHIPPED(p) DONE(d)
 #+TAGS: scrape(s) frontend(f) api(a) agents(g) bugs(b) infra(i) chore(C) chat(c) dedupe(d) extension(e) mcp(m)
 
 * Navigation                                         :IMPORTANT:
@@ -13,13 +13,13 @@ Capture: =SPC X c= → top-level Inbox; =SPC X C= → Inbox/<kind>.
 
 TOC (compiled by =cc-todo-rebuild-toc=):
 #+begin_example
-Inbox (27)
-  Bug (3)
-  Enhancement (1)
-  Feature (1)
-  Idea (1)
+Inbox (18)
+  Bug (2)
+  Enhancement (0)
+  Feature (0)
+  Idea (0)
 Backlog [0/3]
-Active [3/39]
+Active [4/39]
 Icebox [0/4]
 Archive (0)
 #+end_example
@@ -38,55 +38,56 @@ Archive (0)
 - New UI components must use Tailwind utilities following HyperUI patterns. Never custom CSS.
 - Use hyperui, tailwind, and defined color palettes when writing UI html.
 - Submodule scope on entry headings goes in proper org tags (=:frontend:=, =:api:=, =:ai:=, =:bug:=), NOT bracket-suffix annotations like =[frontend]=. Tags stack: =:frontend:bug:=. Don't bulk-rewrite historical =[frontend]= entries.
+** DONE Add nested job-posts.show.scores.show route                                                          :frontend:
+CLOSED: [2026-05-05]
+Extension popup links to /job-posts/<id>/scores/<scoreId> after Score-this-post; that URL 404d in prod because frontend only had a leaf scores route. Added router.js nested show, route+controller+template under app/{routes,controllers,templates}/job-posts/show/scores/show, and {{outlet}} in scores.hbs so detail renders below the list.
+** TODO score spinner not standard
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-05]
+:END:
+** TODO delete -> delete everything should scroll to section with popup.
+job-post.show.delete
 ** TODO ai chat promonent url showing.  user confused about context.
 ** TODO buy me coffee.  cofee leaderborad :frontend:
 ** TODO answer prompt injection jp.show.questions.show.answers.index
 ** TODO omarchy themer needs to change the background highlight darker.
 /home/oldbones/Pictures/screenshot-2026-05-05_09-16-12.png
-** TODO find the link the user is currently on and if we have a jp. link to it for them. 
+** DONE find the link the user is currently on and if we have a jp. link to it for them. 
+CLOSED: [2026-05-05 Tue 12:39]
 ** TODO link to created or duplicate is needed :extension:
-** TODO send.. looks frozen without motion :extension:
-** TODO send... feels like it's frozen without motion :extension:
+** DONE send... feels like it's frozen without motion :extension:
+CLOSED: [2026-05-05 Tue 12:39]
 ** TODO Verify cookie seeding still works after session-token sharing landed
 ResidentBrowser._ensure_context calls ctx.add_cookies once per domain (resident.py:57-65). Untested since the session-token-sharing changes. Verify by: launch attended poller, point at a known auth-walled site (linkedin.com), confirm logged-in state is reached without manual login. If broken, check whether session_store.load() format still matches what add_cookies expects.
 ** Idea
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
 :END:
-*** TODO URL-as-hint for parse agent — ATS query strings carry title/company
-Worksourcewa, LinkedIn, Greenhouse, and many ATS pages encode the
-job title in the URL query string. Example:
-  =https://seeker.worksourcewa.com/jobview/GetJob.aspx?JobID=...&JobTitle=Services+Presales+Senior+Consultant=
-
-The parse agent currently extracts from page text only and has been
-observed hallucinating titles when page-text is sparse or
-demo-shaped. Concrete miss: jp 1765 derived a wrong title from a
-worksourcewa scrape.
-
-Idea: feed the URL to the parse agent prompt as an additional hint
-alongside page text. URL-encoded keys like =JobTitle=, =title=,
-=position= would give the LLM a strong anchor when the body fails
-to surface one.
-
-Open questions:
-- Does the parse agent use ScrapeProfile today? Plain-text path has
-  no HTML, so profile selectors are moot — but ScrapeProfile could
-  carry per-host =url_param_hints= the parse agent reads.
-- Generic vs per-host: a generic parse_qsl scan for known keys
-  [title, jobtitle, position, role, company, employer] is cheap and
-  needs no profile changes. Per-host hints win on accuracy.
-- Interaction with dedupe/canonicalize: =JobTitle= is NOT a
-  tracking param and must stay in canonical_link. Already true
-  today — =_TRACKING_PARAMS= does not strip it.
-
-Tags: =:scrape: :agents:=. Filed as Idea, not Bug — existing
-extraction works on most hosts; this is an accuracy/robustness
-upgrade, not a regression fix.
 ** Feature
+*** TODO Extension settings screen
+Dedicated settings/preferences screen inside the popup, separate from the main Send / Tracked flows. Promotes preferences out of the connected screen and gives a place for upcoming options.
+
+Initial scope (v1):
+- Theme mode pin: light, dark, or follow CC site (the current behavior). Currently the toggle is one-shot and CC site always wins on reopen — a settings screen lets the user opt INTO that behavior or pin explicitly. ccThemeExplicit was just removed but the underlying need (user wants to pin) remains; a settings UI is the right place to surface it.
+- Palette pin: same idea for palette.
+- Default auto-score on Send (the existing checkbox lives here permanently, not just inline on the connected screen).
+- Origin / API host: hidden by default; only shown for self-hosters or if a query string flag is set. Currently hardcoded to =https://api.careercaddy.online=.
+
+Stretch (v2):
+- Notifications on/off
+- Hold-poller / cc_auto integration prefs
+- Import/export settings JSON
+
+UX notes:
+- Gear icon in the footer next to the theme toggle
+- Settings is a 4th screen alongside connect / connected / tracked
+- Footer (theme toggle, who, disconnect) stays consistent across all screens
+
+Tags: =:extension: :frontend:=. Future ship — not v1.0.x.
+*** TODO org -> md -> github wiki exporter for career_caddy
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
 :END:
-*** TODO org -> md -> github wiki exporter for career_caddy
 Goal: publish a curated subset of org docs (architecture, flowcharts, onboarding) to the built-in GitHub wiki at =overcast-software/career_caddy.wiki.git= so non-Emacs readers can browse them at =github.com/overcast-software/career_caddy/wiki=.
 
 Why not just point people at notes.org / todo.org: those are local-only and Emacs-driven; their value is the live tagged tree + state cookies that depend on Emacs. The wiki is for *static reference docs* -- onboarding, architecture overviews, mermaid flowcharts, ingest pipeline writeup. notes.org / todo.org stay where they are.
@@ -109,7 +110,20 @@ Tags: docs, infra
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
 :END:
+*** TODO Show top score on extension tracked panel
+When the popup-open lookup or 409 response surfaces an existing JobPost, render the top score (highest non-archived Score for that JobPost) on the tracked card. Keep title + company as-is; add the score as a badge in the upper-right of the card (the empty slot the user marked with an arrow on the v1.0.3 screenshot 2026-05-05_12-52-24.png — top-right of =.tracked-card=, vertically aligned with =tracked-title=).
+
+Two surfaces:
+- =screen-tracked= (popup-open lookup): expand the existing fetch to =?include=company,scores=. Pick max(score.value); render as a numeric badge top-right of =.tracked-card=.
+- 409 path after Send: server returns =meta.job_post_id= but no score data. Either (a) widen the 409 meta to include a top_score field (api change), or (b) issue a follow-up GET keyed off =meta.job_post_id= from the popup. Option (a) is cheaper at runtime; option (b) keeps the api contract narrower.
+
+When no score exists yet, render nothing (no 'Score: —' placeholder); the slot stays empty.
+
+Tags: =:extension: :frontend:=. Follows the v1.0.x extension thread; ride along with the next ship after extension WIP lands.
 *** TODO cc-todo and cc-notes helpers should accept variadic path segments instead of slash-joined olp
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-05]
+:END:
 Current API: =(claude/cc-todo-read "Inbox/Bug/foo (bar)")= -- chokes when a heading contains =/= or =(...)= because =org-find-olp= splits on =/= and treats parens specially. Hit this on the cc_auto hallucination STRT entry today; had to fall back to =Edit= on the raw file.
 
 Proposed: variadic segments, one heading per arg.
@@ -207,36 +221,6 @@ what jp.show.job-application.show
 :PROPERTIES:
 :TRIAGE_NOTE: candidate=infra conf=0.75
 :END:
-** SHIPPED caddy-web cannont get screenshots
-CLOSED: [2026-05-05 Tue 04:20]
-:PROPERTIES:
-:TRIAGE_NOTE: candidate=infra conf=0.75
-:LAST_TOUCHED: [2026-05-05]
-:END:
-Root cause [2026-05-05]: the happy-path screenshot uploader in
-=agents/scrape_graph/nodes_scrape.py::_screenshot_and_upload= called
-=page.screenshot(path=..., full_page=True)= with no explicit timeout,
-hitting Playwright's 30s "wait for fonts to load" default on every
-LinkedIn login-wall page. Exception caught + logged at WARNING, no
-upload attempted. Failure-path uploader in
-=agents/scrape_graph/_artifacts.py::capture_debug_artifact= already
-used =full_page=False, timeout=5_000= and worked — that's why scrape
-322 (=ziprecruiter.com_obstacle_fail_*=) had a screenshot but 320,
-321, 323, 324, 325 did not. Verified the boundary by listing
-screenshots for each.
-
-Fix [2026-05-05]: extracted =upload_page_screenshot()= shared helper
-in =_artifacts.py= using the safe defaults (viewport-only, 5s
-timeout, in-memory POST — no disk round-trip, no
-=mcp_servers.browser_server.SCREENSHOT_DIR= dependency).
-=_screenshot_and_upload= and =capture_debug_artifact= now both call
-it. 6 new tests in =tests/test_debug_artifact_on_fail.py= cover the
-happy-path filename schema, the safe-defaults regression guard, and
-failure modes.
-
-Stays STRT until parent Deploy lands and a fresh scrape produces a
-=linkedin.com_*= screenshot (no =_obstacle_fail_= segment). Verify
-by hitting =list_scrape_screenshots= on the next post-deploy scrape.
 ** TODO https:  careercaddy.online job-posts 1551
 why two canonical?
 ** boot IP 130.12.180.144
@@ -387,13 +371,21 @@ Scrape Log entry: =Operations/Scrape Log= → =[2026-05-04 21:30]
 ziprecruiter.com — link-normalization: /jobs/v2/<base64> + /km/<token>
 not recognised as same listing_key=
 ** TODO UI fixes
-*** when the user opens the plugin, begin to look for url in the background
-*** if the it exists then offer to take them there
-*** if it doesn't nothing happens until a job-post is created
-*** when new job post is created offer to take them to job-post via the same mechanisms
-*** if auto score was checked offer to take them to job-posts.show.scores.index instead
-*** system alert when a job post is created.  tell them scoring is in progresss if that's what they selected
-*** make sure a user can see the job-post if they were not the creators
+*** DONE when the user opens the plugin, begin to look for url in the background
+CLOSED: [2026-05-05 Tue 11:46]
+*** DONE if the it exists then offer to take them there
+CLOSED: [2026-05-05 Tue 11:46]
+*** DONE if it doesn't nothing happens until a job-post is created
+CLOSED: [2026-05-05 Tue 11:46]
+*** DONE when new job post is created offer to take them to job-post via the same mechanisms
+CLOSED: [2026-05-05 Tue 11:46]
+*** DONE if auto score was checked offer to take them to job-posts.show.scores.index instead
+CLOSED: [2026-05-05 Tue 11:46]
+*** DONE system alert when a job post is created.  tell them scoring is in progresss if that's what they selected
+CLOSED: [2026-05-05 Tue 11:46]
+*** DONE make sure a user can see the job-post if they were not the creators
+CLOSED: [2026-05-05 Tue 11:46]
+*** TODO show score
 ** TODO sundaay :scrape:linkedin:
 :PROPERTIES:
 :CREATED:  2026-05-04
@@ -828,10 +820,9 @@ class TestSweepStuckExtractingCommand(TestCase):
 - Changing the underlying daemon-thread architecture to a real worker
   queue (Celery / Django-Q). That's a larger refactor.
 
-** STRT Extension allFrames capture for iframe-embedded ATS (greenhouse, dat.com class) :extension:frontend:scrape:
+** TODO Extension allFrames capture for iframe-embedded ATS (greenhouse, dat.com class) :extension:frontend:scrape:
 :PROPERTIES:
 :CREATED:  [2026-05-02]
-:LAST_TOUCHED: [2026-05-05]
 :END:
 *Trigger:* scrape 273 from =https://careers.dat.com/jobs/?gh_jid=5741667004&gh_src=fd81f4a54us=
 captured page chrome only (~1.1KB of nav/footer + DAT marketing copy, no
@@ -845,24 +836,7 @@ are invisible.
 This pattern is widespread: any ATS that gets embedded into a company's
 own careers page (greenhouse, lever, workday, jobvite) hits the same gap.
 
-*** TODO Second repro — worksourcewa.com (scrape 350)
-URL: =https://seeker.worksourcewa.com/jobview/GetJob.aspx?JobID=293241789&JobTitle=Cybersecurity+Engineer%2c+Product%2fAI+Security&...=
-
-The =GetJob.aspx= page renders the actual job posting in a same-origin
-iframe. Top-frame =document.body.innerText= captures only the wrapper
-chrome — header, nav, 'Beginning of main content' label, footer —
-totalling ~520 chars with zero job content.
-
-Confirmed by reading =scrape.job_content= directly via MCP: it matches
-the user's paste byte-for-byte. The extension is not corrupting the
-payload; it simply never sees the iframe body.
-
-Tags: =:scrape: :extension:=. Same root cause as the dat.com / greenhouse
-trigger above; same fix.
 *** File :scrape:
-:PROPERTIES:
-:LAST_TOUCHED: [2026-05-05]
-:END:
 
 =frontend/public/extensions/career-caddy-sender/popup.js= — =grabPayload=
 (line 336-342). Bump version in =manifest.json= to 0.3.7 and add a
@@ -1124,6 +1098,18 @@ This todo is *only* the data backfill:
 Out of scope: code changes — the prevention fix is already in the
 profile.
 
+** SHIPPED search still disappears :frontend:scrape:
+CLOSED: [2026-04-30 Thu]
+PR #88 only fixed =scrapes/index=. The other six list routes with a
+=search= QP + =refreshModel: true= (=job-posts=, =companies=, =answers=,
+=questions=, =summaries=, =job-applications=) had the same symptom: in-route
+refresh on each keystroke rendered =index-loading.hbs= (or =loading.hbs=),
+which has no =<:subnav>= slot, so the SearchBar was torn down + remounted
+(focus loss + flicker). Mirrored the =scrapes/index.js= =loading()=
+action override into all six routes — return =true= when the transition
+is in-route (=transition.from.name === this.routeName=) so the substate
+is suppressed; cold loads still get the skeleton.
+[[*Search input flicker on /scrapes \[frontend\]][Original PR #88 — only covered /scrapes]]
 ** STRT a few bugs in this output :important:ai:scrape:
 api PR #81 merged 2026-05-01 21:36 UTC: explicit provider:model prefix
 in JobPostExtractor + IngestResume dispatchers; bare names + unknown


### PR DESCRIPTION
## Summary
| commit | submodule | what |
|--------|-----------|------|
| 3810768 | frontend | nested job-posts.show.scores.show route |

Fixes 404 on `/job-posts/<id>/scores/<scoreId>` — the URL the extension popup builds when the user clicks Score-this-post.