### PR TITLE
chore: pin frontend extension store-assets + ignore secrets/notes-archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ __pycache__/
 .claude/
 todo_archive.org
 notes.org
+notes.org_archive
+secrets.yml
 .envrc


### PR DESCRIPTION
## Summary

| repo | PR | what |
|------|-----|------|
| frontend | #114 | AMO data_collection_permissions + 1280×800 store-assets |
| parent  | this | submodule pin + .gitignore hygiene |

- Pins frontend to merged #114.
- `.gitignore`: add `notes.org_archive` (mirrors notes.org local-only rule) and `secrets.yml` (untracked secret file shouldn't ride a future `git add -A`).

## Test plan

- [x] `make ci` green at the pinned SHA