### PR TITLE
chore: docs hygiene — extension-privacy link + support@→webmaster + poller doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ make ci-ai            # Dagger: build slim AI image (no camoufox)
 make scrape-url URL=https://...   # scrape one job URL → add to Career Caddy
 make poller                          # hold-poller against prod (Camoufox default)
 make poller ARGS="--engine chrome"   # hold-poller with Chromium + stealth (ARM/Pi)
-make poller ARGS="--attended"        # headed browser with per-domain tabs; solve captchas manually (add --attended-delay for a 5s pre-preseed pause, or --attended-delay N for a custom wait)
+make poller ARGS="--attended"        # headed browser; spawns an ephemeral tab per scrape in one resident window and closes it on completion. Cookies persist across scrapes so logins/captchas you solve once stay warm.
 make poller-local                    # hold-poller against localhost:8000 (uses CC_API_TOKEN_LOCAL)
 make doctor                          # check local environment is set up correctly
 make doctor-poller                   # check hold-poller environment

--- a/todo.org
+++ b/todo.org
@@ -125,7 +125,8 @@ Tags: docs, infra
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
 :END:
-*** TODO Link extension-privacy from /docs index
+*** SHIPPED Link extension-privacy from docs index
+CLOSED: [2026-05-06]
 /docs/extension-privacy/ exists and is reachable but not surfaced from the /docs index page. Add a card/link entry alongside career-data, scrapes, etc. so users can discover the extension privacy doc without typing the URL.
 *** TODO Show top score on extension tracked panel
 :PROPERTIES:
@@ -166,7 +167,8 @@ Untriaged. Run =(cc-todo-triage)= to autoroute high-confidence entries; low-conf
 :LAST_TOUCHED: [2026-05-06]
 :END:
 After logout + login as the same user, the popup (or app?) displayed a score belonging to a different user. Possible causes: (1) frontend Ember Data store not cleared on logout — stale records from previous session leak into new one; (2) UX7 made filter[link] visible across users — popup-open lookup may resolve to another user's JobPost id, then pull THAT user's score; (3) backend score endpoint not properly user-scoped. Repro: log out, log in, observe score visible that does not belong to current user. PRIORITY: privacy / auth bug. Investigate before promoting CWS Unlisted listing.
-*** TODO Change support@careercaddy.online to webmaster@careercaddy.online in docs
+*** SHIPPED Change support@careercaddy.online to webmaster@careercaddy.online in docs
+CLOSED: [2026-05-06 Wed 16:17]
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-06]
 :END:


### PR DESCRIPTION
## Summary

Bundles three small docs/copy fixes:

| commit | repo | what |
|--------|------|------|
| 95727ab | parent CLAUDE.md | tighten \`make poller --attended\` doc line (one window, multiple tabs explainer) |
| 1af8432 | frontend #115 | extension-privacy.hbs: \`support@\` → \`webmaster@\`; index.hbs: add Extension Privacy row to docs table |
| 7b1480b | parent | pin frontend submodule + advance todo SHIPPED states |

## Test plan

- [x] `make ci` green at the pinned SHA
- [x] Prettier clean