### PR TITLE
feat: pin Mark incomplete + extension three-state popup (M2)

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -13,7 +13,7 @@ Capture: =SPC X c= → top-level Inbox; =SPC X C= → Inbox/<kind>.
 
 TOC (compiled by =cc-todo-rebuild-toc=):
 #+begin_example
-Inbox (28)
+Inbox (29)
   Bug (4)
   Enhancement (22)
   Feature (2)
@@ -38,6 +38,29 @@ Archive (0)
 - New UI components must use Tailwind utilities following HyperUI patterns. Never custom CSS.
 - Use hyperui, tailwind, and defined color palettes when writing UI html.
 - Submodule scope on entry headings goes in proper org tags (=:frontend:=, =:api:=, =:ai:=, =:bug:=), NOT bracket-suffix annotations like =[frontend]=. Tags stack: =:frontend:bug:=. Don't bulk-rewrite historical =[frontend]= entries.
+** SHIPPED Mark incomplete button + extension popup branching (M2) :frontend:extension:
+CLOSED: [2026-05-08]
+:PROPERTIES:
+:CREATED: [2026-05-08]
+:LAST_TOUCHED: [2026-05-08]
+:END:
+Shipped 2026-05-08 as M2 of the ccsender-as-the-gateway plan's "complete bool" branch.
+
+frontend/:
+- =app/models/job-post.js= gains =@attr('boolean', { defaultValue: true }) complete=. The old =STUB_MIN_WORDS=60= constant + word-count getter are deleted; =isStub= now reads =!this.complete= for backward compat with template consumers (job-posts/list.hbs, job-posts/show.hbs).
+- =app/controllers/job-posts/show.js= gains =markIncomplete= action. Confirm dialog ("Mark this post incomplete so the extension will re-scrape it?"), then PATCHes =complete=false= and flashes success. Rolls back attributes on save error.
+- =app/templates/job-posts/show.hbs= gains a "Mark incomplete" small button next to Edit, gated on =this.model.complete= (hidden when already incomplete; the button is the off-switch).
+- =tests/acceptance/mark-incomplete-test.js= covers visibility-when-complete, hidden-when-incomplete, and click-flips-and-saves with a JobPostStub + window.confirm shim.
+
+extension (=public/extensions/career-caddy-sender/popup.js=, no version bump):
+- =lookupExistingJobPost= now reads =attrs.complete= (default true for older api) and returns it on the lookup result.
+- =resolveOpenScreen= branches three ways instead of two: existing complete JP → showTracked (Open link, today's behavior); existing !complete JP → showConnected with caption =Completing existing post: <title>=; no JP → showConnected (default Send).
+- The from-text endpoint's =existing.complete= bypass (M0) lets the resend through and parse_scrape upgrades the JP in place; CompletenessReviewer (M1) re-flips =complete=True= on success.
+
+Per memory =feedback_no_reflex_version_bumps=, manifest.json stays at 1.1.0 — user will bump when they want a CWS upload.
+
+Unblocks M3 (cc_auto sets =complete=False= on email-stub creation directly).
+
 ** TODO skeleton pages in reports
 ** TODO https://chromewebstore.google.com/detail/career-caddy-sender/pjdajamkhjkemoaogohehcdpfkocofhd
 ** TODO Extension API-key sprawl: dedupe on Connect or auto-expire server-side


### PR DESCRIPTION
## Summary

Pins frontend to `d4b4cf8` (PR #126) — M2 of the JobPost.complete plan.

| commit | submodule | what |
|--------|-----------|------|
| d4b4cf8 | frontend | `JobPost.complete` attr; `Mark incomplete` button on JP detail (confirm dialog → PATCH); extension popup three-state branching (Open / Send-completing / Send) |

End-to-end shape now wired: api M0 (`complete` field + dedup bypass) → api M1 (CompletenessReviewer auto-flips on bad scrapes) → frontend/extension M2 (user can self-flag and the popup respects the flag). Remaining: M3 (cc_auto sets `complete=False` on email-stub creation directly).

## Test plan

- [x] `make ci` exit 0 locally
- [ ] Deploy turns green on this merge