### PR TITLE
Mark-incomplete acceptance + concise CI test reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,33 @@ ci-lint-api:
 ci-lint-frontend:
 	dagger -m ./dagger call lint-frontend
 
+# Concise reports: surface failure blocks + summary; suppress dagger noise.
+# Pass FULL=1 to dump the entire test log unfiltered.
 ci-test-api:
-	dagger -m ./dagger call test-api
+	@set -o pipefail; \
+	if [ -n "$(FULL)" ]; then \
+		dagger -m ./dagger call test-api stdout 2>/dev/null; \
+	else \
+		dagger -m ./dagger call test-api stdout 2>/dev/null | awk ' \
+			/^(FAIL|ERROR): / { hit=1; n=25 } \
+			/^={70}/ { hit=1; n=25 } \
+			/^Ran [0-9]+ tests/ { print } \
+			/^(OK|FAILED)( |$$)/ { print } \
+			hit { print; if (n-- <= 0) hit=0 } \
+		'; \
+	fi
 
 ci-test-frontend:
-	dagger -m ./dagger call test-frontend
+	@set -o pipefail; \
+	if [ -n "$(FULL)" ]; then \
+		dagger -m ./dagger call test-frontend stdout 2>/dev/null; \
+	else \
+		dagger -m ./dagger call test-frontend stdout 2>/dev/null | awk ' \
+			/^not ok / { hit=1; n=20; print; next } \
+			/^# (tests|pass|fail|skip|todo) / { print } \
+			hit { print; if (n-- <= 0) hit=0 } \
+		'; \
+	fi
 
 ci-lint: ci-lint-api ci-lint-frontend
 ci-test: ci-test-api ci-test-frontend

--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -165,8 +165,13 @@ class CareerCaddy:
             # zero tests collected or swallowed failures, require the
             # canonical success markers in the log. Tally #9/#13/#14/#19 —
             # this assertion closes the green-but-broken gap.
+            #
+            # Cat the log first so `dagger call test-api stdout` returns
+            # the test output (otherwise the grep-q exec is silent and
+            # downstream filters have nothing to chew on).
             .with_exec([
                 "sh", "-c",
+                "cat /test.log; "
                 "grep -qE '^Ran [1-9][0-9]* test' /test.log "
                 "&& grep -qE '^OK( |$)' /test.log",
             ])
@@ -191,8 +196,13 @@ class CareerCaddy:
             # Belt-and-suspenders: even if the runner ever exits 0 with
             # zero passes or non-zero fails, require the canonical TAP
             # summary in the log. Tally #9/#13/#14/#19.
+            #
+            # Cat the log first so `dagger call test-frontend stdout`
+            # returns the TAP (otherwise the grep-q exec is silent and
+            # downstream filters have nothing to chew on).
             .with_exec([
                 "sh", "-c",
+                "cat /tap.log; "
                 "grep -qE '^# fail +0$' /tap.log "
                 "&& grep -qE '^# pass +[1-9]' /tap.log",
             ])


### PR DESCRIPTION
## Summary

| commit | submodule | what |
|---|---|---|
| `fbb2e6b` | frontend (`cd16d37`) | refactor `JobPosts::DuplicateCandidates` to use a real Ember Data model + adapter (no more `store.adapterFor('job-post').ajax(...)`); add `data-test-mark-incomplete` selector; new mark-incomplete acceptance test |
| `fbb2e6b` | parent | dagger pipeline cats the test log before assertion so \`dagger call test-{api,frontend} stdout\` returns useful bytes; Makefile filters that stream into failure blocks + summary lines |

The dagger/Makefile change is independent of M2 but came out of the same session — both targeted "make CI feedback useful at a glance."

## Test plan

- [x] \`make ci-test-frontend\` — 284/284 passing
- [x] \`make ci-test-api\` — 821/821 passing, OK
- [x] frontend PR #128 merged with admin (carrier branch is shared)