### PR TITLE
chore: bump frontend pin — Mark-incomplete on /edit + ccsender 1.1.1

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -128,7 +128,13 @@ Tags: docs, infra
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
 :END:
+*** SHIPPED Move Mark-incomplete to edit + ccsender 1.1.1 resend UX
+CLOSED: [2026-05-08]
+frontend show.hbs button moved to edit.hbs (HyperUI amber pill); markIncomplete action moved to edit controller; mark-incomplete acceptance test now visits /edit. ccsender extension bumped 1.1.0 → 1.1.1 with resend-to-complete UX: showConnected swaps heading to 'Complete this post' and button to 'Resend to complete' when the active URL maps to a complete=false JobPost; new accent-colored banner shows existing post title+company. Disambiguates from earlier in-place 1.1.0 build (commit d2ea3da) that shipped the three-state branching without a version bump.
 *** TODO remove expand caret on sidebar
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-08]
+:END:
 remove the expand carrot on the sidebar
 *** TODO skeleton pages in reports
 :PROPERTIES:


### PR DESCRIPTION
## Summary

| commit | submodule | what |
|--------|-----------|------|
| 8c6ca63 | frontend | Mark-incomplete on /edit; ccsender 1.1.1 resend UX |

Companion to [career_caddy_frontend #129](https://github.com/overcast-software/career_caddy_frontend/pull/129). Bumps the parent submodule pin so prod picks up both the show→edit move and the disambiguating ccsender 1.1.1 manifest.

## Test plan

- [ ] Local: \`make ci\` — frontend 284/284, api 829/829, lint clean.
- [ ] Post-Deploy: \`/job-posts/:id/edit\` shows Mark-incomplete pill on complete=true posts.
- [ ] Post-Deploy: extension popup re-installed at 1.1.1 shows "Complete this post" / "Resend to complete" UX on a complete=false JobPost URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)