### PR TITLE
chore: bump agents pin — ResolveFinalUrl networkidle re-read for JS redirects

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -352,6 +352,24 @@ Lives in =~/.config/doom/config.org=.
 :END:
 Untriaged. Run =(cc-todo-triage)= to autoroute high-confidence entries; low-confidence ones stay here with a =:TRIAGE_NOTE:= drawer.
 
+*** SHIPPED Navigate captures URL pre-JS-redirect — ResolveFinalUrl never re-reads page.url
+CLOSED: [2026-05-08]
+agents/scrape_graph/nodes_scrape.py:267-268: page.goto(target_url, wait_until="domcontentloaded") + state.final_url=page.url captures the URL BEFORE JS / meta-refresh redirects fire. Email-tracker URLs - ZipRecruiter /km/<token>, SendGrid /ls/click, Mailgun /c/ - all redirect via meta-refresh or window.location after domcontentloaded; Navigate already returned by then, so state.final_url is frozen at the tracker URL. ResolveFinalUrl at nodes_scrape.py:283 reads state.final_url, sees it equals state.submitted_url, early-exits with did_redirect=false, never creates the child scrape, canonical_link stays as /km/<token>.
+
+Evidence: scrape 394 = jp 1908 graph trace, 2026-05-08 20:05:38 prod, ResolveFinalUrl duration_ms=0 did_redirect=false canonical_url=/km/<opaque>. Confirms the comment at Navigate that picked domcontentloaded over load to dodge LinkedIn /comm/ auth-interstitial deadlocks - fair for that case, leaves JS redirects unchaperoned.
+
+Fix scope: in ResolveFinalUrl.run, before _resolve_final_url_body, await page.wait_for_load_state networkidle timeout=5_000 then re-read page.url into state.final_url. Wrap in best-effort try/except so a slow tracker cannot park ResolveFinalUrl past its 15s budget. Navigate stays unchanged so its deadlock-safety holds.
+
+Regression test - agents: mock a Playwright page whose .goto returns immediately at /km/, then a delayed .url that flips to the canonical after a tick. Assert ResolveFinalUrl populates did_redirect=true + creates the child scrape + state.canonical_url is the post-redirect URL.
+
+Verification - manual, post-deploy: re-run a scrape against jp 1908 /km/<opaque> URL with caddy-poller --attended; graph trace should show ResolveFinalUrl did_redirect=true canonical_url=https://www.ziprecruiter.com/jobs/altus-llc-x/. With today landed canonical_link OR-leg dedup at parent b2c9ba8 / api 67a5295, the child scrape would then collapse onto jp 1923 or 1924 in parse_scrape link_hit.
+
+Out of scope: ZipRecruiter /km/ tracking-param strip lk lvk tsid is a separate _TRACKING_PARAMS PR. ZipRecruiter url_rewrites for slug-suffix tokens is a separate ScrapeProfile PR. LinkedIn apply selectors stale apply_resolver_config no_selector_matched is a separate ScrapeProfile PR. ZipRecruiter empty ready_selector is a separate ScrapeProfile PR.
+
+Files:
+- agents/scrape_graph/nodes_scrape.py:336 ResolveFinalUrl.run
+- agents/scrape_graph/nodes_scrape.py:241-273 Navigate, do not touch
+- agents/tests/test_scrape_graph_state.py or new test file for regression
 *** TODO Logout/login shows another user's score
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-08]


### PR DESCRIPTION
## Summary

| commit | submodule | what |
|--------|-----------|------|
| fe1d56c | agents | ResolveFinalUrl: networkidle wait + page.url re-read for JS / meta-refresh trackers |

Companion to [career_caddy_agents #19](https://github.com/overcast-software/career_caddy_agents/pull/19). Bumps the submodule pin so the JS-redirect class fix lands in prod.

## Test plan

- [x] Local: \`make ci\` (api 830/830, frontend 284/284, lint clean)
- [x] \`uv run pytest tests/\` in agents/: 301/301
- [ ] Post-deploy: re-run a scrape against jp 1908's \`/km/\` URL with \`caddy-poller --attended\`. Graph trace should show \`ResolveFinalUrl did_redirect=true canonical_url=https://www.ziprecruiter.com/jobs/altus-llc-…/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)