### PR TITLE
feat: cover-letter nested show + Parent/Resource primitives + Makefile stderr fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,9 @@ ci-lint-frontend:
 ci-test-api:
 	@set -o pipefail; \
 	if [ -n "$(FULL)" ]; then \
-		dagger -m ./dagger call test-api stdout 2>/dev/null; \
+		dagger -m ./dagger call test-api stdout 2>&1; \
 	else \
-		dagger -m ./dagger call test-api stdout 2>/dev/null | awk ' \
+		dagger -m ./dagger call test-api stdout 2>&1 | awk ' \
 			/^(FAIL|ERROR): / { hit=1; n=25 } \
 			/^={70}/ { hit=1; n=25 } \
 			/^Ran [0-9]+ tests/ { print } \
@@ -112,9 +112,9 @@ ci-test-api:
 ci-test-frontend:
 	@set -o pipefail; \
 	if [ -n "$(FULL)" ]; then \
-		dagger -m ./dagger call test-frontend stdout 2>/dev/null; \
+		dagger -m ./dagger call test-frontend stdout 2>&1; \
 	else \
-		dagger -m ./dagger call test-frontend stdout 2>/dev/null | awk ' \
+		dagger -m ./dagger call test-frontend stdout 2>&1 | awk ' \
 			/^not ok / { hit=1; n=20; print; next } \
 			/^# (tests|pass|fail|skip|todo) / { print } \
 			hit { print; if (n-- <= 0) hit=0 } \

--- a/todo.org
+++ b/todo.org
@@ -39,6 +39,12 @@ Archive (0)
 - New UI components must use Tailwind utilities following HyperUI patterns. Never custom CSS.
 - Use hyperui, tailwind, and defined color palettes when writing UI html.
 - Submodule scope on entry headings goes in proper org tags (=:frontend:=, =:api:=, =:ai:=, =:bug:=), NOT bracket-suffix annotations like =[frontend]=. Tags stack: =:frontend:bug:=. Don't bulk-rewrite historical =[frontend]= entries.
+** TODO capture prompt used.
+** DONE jp.show.cover-letters.show
+CLOSED: [2026-05-12]
+Introduced nested =job-posts.show.cover-letters.show= route — clicking View on a cover-letter row from a JP page now lands inside the JP context instead of bouncing to the top-level =/cover-letters/:id=. Frontend changes: new =in-route-scope= helper, =<ResourceLink>= (flat vs nested LinkTo by parent scope), =<ParentReference>= (hides redundant breadcrumb when already inside parent scope) so =cover-letters/item= drops its "for [JP] at [Company]" header on the nested show. Restyled =scores=, =summaries=, =job-applications/index=, and =cover-letters= parent template into uniform =panel-card= "New X" form + section list. On the nested show, the form+list collapse into a single "← Cover letters" / "← Scores" back-link so the focused record sits near the top.
+** TODO coverletter ai produced two
+** TODO /cover/letter.show should have jp and company
 ** TODO backup prod db
 ** TODO new user, no wizard on localhost:4200
 ** TODO ZipRecruiter dedup gaps — three URL shapes for the same job  :scrape:dedupe:bug:
@@ -158,8 +164,38 @@ Tags: docs, infra
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
 :END:
+*** TODO Cover-letter parity: scrapes tab
+Replicate the navigation/component improvements on the scrapes tab. Skip the panel-card AI-prompt wrapper per [2026-05-12] direction — scrape has no AI prompt textarea. Nested show route already exists at =job-posts.show.scrapes.show=. To do: (a) =<ResourceLink>= for the scrapes list row View link so it targets flat or nested based on parent scope; (b) =<ParentReference>= around the Scrapes::Item job-post header so it hides when inside =job-posts.show.scrapes.show=; (c) on =/scrapes= index, the JP-column LinkTo should target =job-posts.show.scrapes.show= with =[jobPost, scrape]=; (d) collapse the form + scrapes list when nested show is active — single "← Scrapes" back-link. Reference: =app/components/cover-letters/{list,item}.hbs= for the ResourceLink + ParentReference swaps; =app/templates/job-posts/show/cover-letters.hbs= for the collapse pattern.
+*** TODO Cover-letter parity: summaries tab
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-12]
+:END:
+Replicate the cover-letter improvements on the summaries tab. Done this session: panel-card "New summary" wrapper + =Summaries= section list wrapper. Largest gap: there is NO nested show route. Need to add =job-posts.show.summaries.show= with route/controller/template trio (mirror the cover-letter trio under =app/routes|controllers|templates/job-posts/show/cover-letters/=). Router change: =this.route('summaries', function() { this.route('show', { path: '/:summary_id' }); });= Then: (a) =<ResourceLink>= in =components/summaries/list.hbs= for the row View link; (b) =<ParentReference>= around the Summaries::Item job-post header so it hides when nested; (c) on =/summaries= index, the JP-column LinkTo should target the nested show with =[jobPost, summary]=; (d) consolidate any item-show action buttons into the item =panel-actions= slot; (e) collapse the form + list when nested show is active — "← Summaries" back-link. Reference: the cover-letter trio under =app/{routes,controllers,templates}/job-posts/show/cover-letters/=.
+*** TODO Cover-letter parity: questions tab
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-12]
+:END:
+Replicate the cover-letter improvements on the questions tab. Nested show route already exists at =job-posts.show.questions.show=. Skip the panel-card wrapper — existing question wrapper is already good per [2026-05-12] direction. Still to do: (a) =<ResourceLink>= on the questions list row View link so it targets flat or nested based on parent scope; (b) =<ParentReference>= around the Questions::Item job-post header so it hides when inside =job-posts.show.questions.show= (and within answers.show inside that); (c) on =/questions= index, the JP-column LinkTo should target =job-posts.show.questions.show= with =[jobPost, question]=; (d) collapse the form + questions list when nested show is active — single "← Questions" back-link. Bonus: same pattern can flow down one more level to =job-posts.show.questions.show.answers.show= where Answers::Item drops its question-quote breadcrumb (the strongest =ParentReference= case). Reference: =app/components/cover-letters/list.hbs= + =cover-letters/item.hbs=.
+*** TODO Cover-letter parity: scores tab
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-12]
+:END:
+Replicate remaining cover-letter improvements on the scores tab. Nested show route already exists at =job-posts.show.scores.show=. Done this session: panel-card "New score" wrapper, =Scores= section list wrapper, and the collapse-to-back-link pattern on the nested show. Still to do: (a) =<ResourceLink>= in =components/scores/list.hbs= so the row View link targets flat or nested based on parent scope; (b) =<ParentReference>= around the Scores::Item job-post header so it hides when inside =job-posts.show.scores.show=; (c) on =/scores= index, the JP-column LinkTo should target =job-posts.show.scores.show= with =[jobPost, score]=; (d) consolidate any floating action buttons on the score show page into the item =panel-actions= slot. Reference: =app/components/cover-letters/list.hbs= LinkTo→ResourceLink swap and =cover-letters/item.hbs= ParentReference wrap.
+*** TODO Cover-letter parity: job-applications tab
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-12]
+:END:
+Replicate the cover-letter improvements on the job-applications tab. Nested show route already exists at =job-posts.show.job-applications.show=. Done this session: panel-card "New application" wrapper around the resume picker + Apply LinkTo. Still to do: (a) =<ResourceLink>= in =components/job-applications/compact.hbs= so the row View link targets flat or nested based on parent scope; (b) =<ParentReference>= around the JA item header ("For [JP] at [Company]") so it hides when inside =job-posts.show.job-applications.show=; (c) on =/job-applications= index, the JP-column LinkTo should target =job-posts.show.job-applications.show= with =[jobPost, application]=; (d) consolidate floating action buttons on the JA show page into the item card =panel-actions= slot; (e) collapse the "New application" form + applications list when nested show is active — show a single "← Applications" back-link. Reference: =app/templates/job-posts/show/cover-letters.hbs= + =components/cover-letters/{list,item}.{hbs,js}=.
+*** TODO Collapse form+list on remaining jp.show.* tabs with nested shows
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-12]
+:END:
+Apply the in-route-scope collapse pattern (introduced for cover-letters and scores) to the other jp.show.* sub-tabs that have nested .show routes — questions, scrapes, applications. When the nested show is active, render a single "← <Tab>" back-link in place of the form panel + list section so the focused record sits near the top of the tabbed content. Reference templates: app/templates/job-posts/show/cover-letters.hbs + scores.hbs. Helper: in-route-scope.
 *** SHIPPED Move Mark-incomplete to edit + ccsender 1.1.1 resend UX
 CLOSED: [2026-05-08]
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-12]
+:END:
 frontend show.hbs button moved to edit.hbs (HyperUI amber pill); markIncomplete action moved to edit controller; mark-incomplete acceptance test now visits /edit. ccsender extension bumped 1.1.0 → 1.1.1 with resend-to-complete UX: showConnected swaps heading to 'Complete this post' and button to 'Resend to complete' when the active URL maps to a complete=false JobPost; new accent-colored banner shows existing post title+company. Disambiguates from earlier in-place 1.1.0 build (commit d2ea3da) that shipped the three-state branching without a version bump.
 *** TODO remove expand caret on sidebar
 :PROPERTIES:


### PR DESCRIPTION
## Summary

| commit | repo | what |
|---|---|---|
| f8b919b | frontend | `feat(cover-letters): nested show + ParentReference / ResourceLink primitives` ([PR #142](https://github.com/overcast-software/career_caddy_frontend/pull/142)) |
| 8d2ae68 | parent | bump frontend pin + Makefile fix + todo.org |

## Frontend changes (pinned at b7173fd)

- Nested route `job-posts.show.cover-letters.show` so View on a cover-letter row from a JP page stays inside the JP.
- New primitives: `(in-route-scope "<scope>")` helper, `<ResourceLink>` (flat vs nested LinkTo by parent scope), `<ParentReference>` (yields breadcrumb block only when out of scope).
- Style pass: matching `panel-card` "New X" form + section list pair on the four JP-show form tabs (cover-letters, scores, summaries, applications).
- Action consolidation: Favorite + Edit + Export now live in the cover-letter item's `panel-actions` slot.
- Collapse pattern: `jp.show.cover-letters.show` and `jp.show.scores.show` hide form+list and render a single back-link.
- `/cover-letters` JP-column link deep-links into the nested route.

## Parent-only changes

- **Makefile** — `ci-test-{api,frontend}` was piping dagger stderr to /dev/null, so when a container exits non-zero its failure-block payload (which dagger emits on stderr) never reached the awk filter and `make ci-test-*` returned no useful output. Changed to `2>&1` so the failure block streams through and the awk filter can do its job. This was a daily papercut — local CI failures would print nothing actionable.
- **todo.org** — Inbox/Bug `jp.show.cover-letters.show` marked DONE [2026-05-12]; five new Inbox/Enhancement entries with per-tab cover-letter-parity scope (ja, scores, questions, summaries, scrapes).

## Local verification

- frontend: 348 / 348 pass, 0 fail
- api: 845 tests OK
- lint: prettier + eslint + template-lint + stylelint all green
- pinned api SHA already on main from earlier `chore: bump submodule pins to current main` (2b59a04)

## Test plan

- [ ] `/cover-letters/:id` standalone — title + Favorite/Edit/Export in panel.
- [ ] `/job-posts/:id/cover-letters` — list + form visible, click View → `/job-posts/:id/cover-letters/:cl_id` with form+list collapsed.
- [ ] `/job-posts/:id/scores/:score_id` — same collapse behavior.
- [ ] `/cover-letters` JP-column link goes into JP context.
- [ ] Verify `make ci-test-frontend` prints failure block + summary when something fails.