### PR TITLE
Cover-letter parity: bump frontend SHA + close inbox

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -14,9 +14,9 @@ Capture: =SPC X c= → top-level Inbox; =SPC X C= → Inbox/<kind>.
 
 TOC (compiled by =cc-todo-rebuild-toc=):
 #+begin_example
-Inbox (35)
+Inbox (32)
   Bug (3)
-  Enhancement (31)
+  Enhancement (25)
   Feature (2)
   Idea (0)
 Backlog [0/3]
@@ -40,9 +40,30 @@ Archive (0)
 - Use hyperui, tailwind, and defined color palettes when writing UI html.
 - Submodule scope on entry headings goes in proper org tags (=:frontend:=, =:api:=, =:ai:=, =:bug:=), NOT bracket-suffix annotations like =[frontend]=. Tags stack: =:frontend:bug:=. Don't bulk-rewrite historical =[frontend]= entries.
 ** TODO capture prompt used.
+** DONE jp.show.cover-letters.show
+CLOSED: [2026-05-12 Tue]
+Nested =job-posts.show.<resource>.show= now exists for all JP-context
+tabs: cover-letters (#151), scrapes, summaries, questions, scores,
+job-applications (this PR). View buttons in the matching list components
+route to the nested show whenever the record has a =jobPost=, falling
+back to the flat route only for JP-less records (career-data summaries,
+orphan scrapes). Implemented as explicit
+={{#if record.jobPost.id}}<LinkTo nested>{{else}}<LinkTo flat>{{/if}}=
+in each list — the earlier ResourceLink wrapper that branched on
+=router.currentRouteName= was removed for readability.
 ** TODO coverletter ai produced two
-** TODO /cover/letter.show should have jp and company
-** TODO backup prod db
+** DONE /cover/letter.show should have jp and company
+CLOSED: [2026-05-12 Tue]
+=<ParentReference @parent=… @parentScope="job-posts.show">= yields the
+"for [JP] at [Company]" breadcrumb on every resource item template
+(cover-letter, scrape, summary, question, score, job-application) when
+viewed outside the JP context, and hides it when already inside
+=job-posts.show=. Cover-letters got it in #151; this PR extends to the
+remaining five resources, plus refactors =Scores::Item= to the
+=panel-card / panel-title / panel-body= shape so its breadcrumb lives
+in the title slot like the rest.
+** DONE backup prod db
+CLOSED: [2026-05-12 Tue 11:49]
 ** TODO new user, no wizard on localhost:4200
 ** TODO ZipRecruiter dedup gaps — three URL shapes for the same job  :scrape:dedupe:bug:
 Repro: jp 1908 (source=email, /km/<opaque>), jp 1923 (source=extension, /jobs/altus-llc-2287a4f5/software-developer-c-remote-2ffd5d4c?lk=…&tsid=…), jp 1924 (source=extension, /jobs/altus-llc/software-developer-c-remote?lvk=…). Same Altus Engineering C++ Software Developer role. canonical_link == link on all three (canonicalize_link is a no-op for ZipRecruiter — no profile rewrites, no tracking-param strip).
@@ -65,7 +86,7 @@ Files:
 Smallest test once #1+#2 land: =test_scrape_from_text.py= case where jp exists at /jobs/altus-llc-<token>/<jobslug>-<token>?lk=… and a new submission lands at /jobs/altus-llc/<jobslug>?lvk=…; assert 409 with =meta.job_post_id= pointing at existing.
 
 Out of scope: SQL re-pointing of =duplicate_of_id= for 1908/1923/1924 — user handles via SQL. /km/ resolution at cc_auto email-parse time is its own follow-up.
-** TODO when clicking on possible duplicate link, the resulting job-post is the duplicate but the possible duplicate warning never chagnes to the other d
+** TODO When Clicking on possible duplicate link, the resulting job-post is the duplicate but the possible duplicate warning never chagnes to the other d
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-08]
 :END:
@@ -161,38 +182,8 @@ Tags: docs, infra
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
 :END:
-*** TODO Cover-letter parity: scrapes tab
-Replicate the navigation/component improvements on the scrapes tab. Skip the panel-card AI-prompt wrapper per [2026-05-12] direction — scrape has no AI prompt textarea. Nested show route already exists at =job-posts.show.scrapes.show=. To do: (a) =<ResourceLink>= for the scrapes list row View link so it targets flat or nested based on parent scope; (b) =<ParentReference>= around the Scrapes::Item job-post header so it hides when inside =job-posts.show.scrapes.show=; (c) on =/scrapes= index, the JP-column LinkTo should target =job-posts.show.scrapes.show= with =[jobPost, scrape]=; (d) collapse the form + scrapes list when nested show is active — single "← Scrapes" back-link. Reference: =app/components/cover-letters/{list,item}.hbs= for the ResourceLink + ParentReference swaps; =app/templates/job-posts/show/cover-letters.hbs= for the collapse pattern.
-*** TODO Cover-letter parity: summaries tab
-:PROPERTIES:
-:LAST_TOUCHED: [2026-05-12]
-:END:
-Replicate the cover-letter improvements on the summaries tab. Done this session: panel-card "New summary" wrapper + =Summaries= section list wrapper. Largest gap: there is NO nested show route. Need to add =job-posts.show.summaries.show= with route/controller/template trio (mirror the cover-letter trio under =app/routes|controllers|templates/job-posts/show/cover-letters/=). Router change: =this.route('summaries', function() { this.route('show', { path: '/:summary_id' }); });= Then: (a) =<ResourceLink>= in =components/summaries/list.hbs= for the row View link; (b) =<ParentReference>= around the Summaries::Item job-post header so it hides when nested; (c) on =/summaries= index, the JP-column LinkTo should target the nested show with =[jobPost, summary]=; (d) consolidate any item-show action buttons into the item =panel-actions= slot; (e) collapse the form + list when nested show is active — "← Summaries" back-link. Reference: the cover-letter trio under =app/{routes,controllers,templates}/job-posts/show/cover-letters/=.
-*** TODO Cover-letter parity: questions tab
-:PROPERTIES:
-:LAST_TOUCHED: [2026-05-12]
-:END:
-Replicate the cover-letter improvements on the questions tab. Nested show route already exists at =job-posts.show.questions.show=. Skip the panel-card wrapper — existing question wrapper is already good per [2026-05-12] direction. Still to do: (a) =<ResourceLink>= on the questions list row View link so it targets flat or nested based on parent scope; (b) =<ParentReference>= around the Questions::Item job-post header so it hides when inside =job-posts.show.questions.show= (and within answers.show inside that); (c) on =/questions= index, the JP-column LinkTo should target =job-posts.show.questions.show= with =[jobPost, question]=; (d) collapse the form + questions list when nested show is active — single "← Questions" back-link. Bonus: same pattern can flow down one more level to =job-posts.show.questions.show.answers.show= where Answers::Item drops its question-quote breadcrumb (the strongest =ParentReference= case). Reference: =app/components/cover-letters/list.hbs= + =cover-letters/item.hbs=.
-*** TODO Cover-letter parity: scores tab
-:PROPERTIES:
-:LAST_TOUCHED: [2026-05-12]
-:END:
-Replicate remaining cover-letter improvements on the scores tab. Nested show route already exists at =job-posts.show.scores.show=. Done this session: panel-card "New score" wrapper, =Scores= section list wrapper, and the collapse-to-back-link pattern on the nested show. Still to do: (a) =<ResourceLink>= in =components/scores/list.hbs= so the row View link targets flat or nested based on parent scope; (b) =<ParentReference>= around the Scores::Item job-post header so it hides when inside =job-posts.show.scores.show=; (c) on =/scores= index, the JP-column LinkTo should target =job-posts.show.scores.show= with =[jobPost, score]=; (d) consolidate any floating action buttons on the score show page into the item =panel-actions= slot. Reference: =app/components/cover-letters/list.hbs= LinkTo→ResourceLink swap and =cover-letters/item.hbs= ParentReference wrap.
-*** TODO Cover-letter parity: job-applications tab
-:PROPERTIES:
-:LAST_TOUCHED: [2026-05-12]
-:END:
-Replicate the cover-letter improvements on the job-applications tab. Nested show route already exists at =job-posts.show.job-applications.show=. Done this session: panel-card "New application" wrapper around the resume picker + Apply LinkTo. Still to do: (a) =<ResourceLink>= in =components/job-applications/compact.hbs= so the row View link targets flat or nested based on parent scope; (b) =<ParentReference>= around the JA item header ("For [JP] at [Company]") so it hides when inside =job-posts.show.job-applications.show=; (c) on =/job-applications= index, the JP-column LinkTo should target =job-posts.show.job-applications.show= with =[jobPost, application]=; (d) consolidate floating action buttons on the JA show page into the item card =panel-actions= slot; (e) collapse the "New application" form + applications list when nested show is active — show a single "← Applications" back-link. Reference: =app/templates/job-posts/show/cover-letters.hbs= + =components/cover-letters/{list,item}.{hbs,js}=.
-*** TODO Collapse form+list on remaining jp.show.* tabs with nested shows
-:PROPERTIES:
-:LAST_TOUCHED: [2026-05-12]
-:END:
-Apply the in-route-scope collapse pattern (introduced for cover-letters and scores) to the other jp.show.* sub-tabs that have nested .show routes — questions, scrapes, applications. When the nested show is active, render a single "← <Tab>" back-link in place of the form panel + list section so the focused record sits near the top of the tabbed content. Reference templates: app/templates/job-posts/show/cover-letters.hbs + scores.hbs. Helper: in-route-scope.
 *** SHIPPED Move Mark-incomplete to edit + ccsender 1.1.1 resend UX
 CLOSED: [2026-05-08]
-:PROPERTIES:
-:LAST_TOUCHED: [2026-05-12]
-:END:
 frontend show.hbs button moved to edit.hbs (HyperUI amber pill); markIncomplete action moved to edit controller; mark-incomplete acceptance test now visits /edit. ccsender extension bumped 1.1.0 → 1.1.1 with resend-to-complete UX: showConnected swaps heading to 'Complete this post' and button to 'Resend to complete' when the active URL maps to a complete=false JobPost; new accent-colored banner shows existing post title+company. Disambiguates from earlier in-place 1.1.0 build (commit d2ea3da) that shipped the three-state branching without a version bump.
 *** TODO remove expand caret on sidebar
 :PROPERTIES:


### PR DESCRIPTION
## Summary

Parent SHA bump for the cover-letter parity work landed in frontend PR #143. Extends the ParentReference + nested-show pattern from PR #151 (cover-letters only) to all five remaining JP-resource tabs. View buttons now keep users inside the JP context.

| commit | submodule | what |
|--------|-----------|------|
| 9f23677 | frontend → f99b489 | scrapes/summaries/questions/scores/job-applications now have ParentReference breadcrumbs + nested `job-posts.show.<resource>.show` View routing; ResourceLink wrapper removed in favor of explicit `{{#if record.jobPost.id}}<LinkTo nested>{{else}}<LinkTo flat>{{/if}}` |

Inbox TODOs closed:
- `jp.show.cover-letters.show` — broader parity across all resources, not just cover-letters
- `/cover/letter.show should have jp and company` — ParentReference breadcrumb on every resource item template

## Test plan

- [x] `make ci` green locally: api 845 OK, frontend 346/346 pass, all lint clean
- [x] Frontend PR #143 merged at f99b489
- [ ] Deploy workflow on parent main picks up the new SHA