### PR TITLE
fix: hold-poller log misattribution after ResolveFinalUrl swap

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -673,31 +673,20 @@ What I'd recommend:
 
 Do you have the direct job post link, or would you like me to check the job post (ID 1667) for any other URL we can use?
 
-** TODO Hold-poller "graph done" log uses entry-time scrape_id (false-positive success on parent) :scrape:agents:bug:obs:
+** DONE Hold-poller "graph done" log uses entry-time scrape_id (false-positive success on parent) :scrape:agents:bug:obs:
+CLOSED: [2026-05-12 Tue]
    :PROPERTIES:
    :CREATED:  2026-05-04
    :END:
-   When ResolveFinalUrl creates a child scrape and swaps =state.scrape_id=,
-   downstream nodes correctly target the child — but the hold-poller's
-   terminal log line ("Scrape %s graph done outcome=%s job_post_id=%s
-   tiers=%d") is hardcoded to the *original* (entry-time) scrape_id. So
-   the child's success is reported in logfire under the parent's id.
-   Confirmed on scrape 302 (LinkedIn /uas/login redirect): logfire shows
-   "Scrape 302 graph done outcome=success" twice, while scrape 302 itself
-   was stuck at status='running' and the work actually happened on child
-   scrape 303 (linked to jp 1647).
-
-   Now that c5dc5b8 terminal-closes the parent, the parent will reach a
-   real terminal state — but the success log line is still misattributed.
-   That makes logfire/grep-driven debugging actively misleading: a search
-   for "Scrape 302 graph done" finds two success entries even though
-   scrape 302 itself produced no JobPost.
-
-   Fix: capture the swap in =state.scrape_id_chain= (or similar) and have
-   the terminal log emit both the entry id and the final id, e.g.
-   ="Scrape 302→303 graph done outcome=success ..."=. Or just use
-   =state.scrape_id= (the post-swap value) so the message points at the
-   row that actually carries the work.
+   Took the "render entry→final when the swap happened" path. New
+   module-level =format_scrape_label(entry_id, final_id)= in
+   =agents/pollers/hold_poller.py= produces ="302→303"= when
+   ResolveFinalUrl forked, or ="273"= otherwise. Applied to all three
+   terminal surfaces: "graph done", graph-cap timeout, and
+   graph-exception. =update_scrape()= calls still target the entry id
+   (parent row is the user-visible one; ResolveFinalUrl's
+   terminal-close handles the parent's status separately).
+   Tests in =tests/test_hold_poller_label.py= lock the format.
 
 ** TODO ResolveApplyUrl: short-circuit on internal_apply_markers (Easy Apply false-fail) :scrape:agents:bug:
    :PROPERTIES:


### PR DESCRIPTION
## Summary

| commit | submodule | what |
|--------|-----------|------|
| 770a17d | agents → 1872a62 | hold_poller terminal log lines render \`entry→final\` when ResolveFinalUrl forked a child scrape |

\`ResolveFinalUrl\` forks a child scrape and swaps \`state.scrape_id\`; downstream nodes and the resulting JobPost belong to the child. The hold-poller's terminal \"graph done\" log was hardcoded to the entry-time scrape_id, so the child's outcome got attributed to the parent in logfire.

**Repro (scrape 302, LinkedIn /uas/login redirect)**: logfire showed \"Scrape 302 graph done outcome=success\" twice while row 302 itself stayed \`running\` and the work actually happened on child 303. A logfire search for \"Scrape 302 graph done\" returned false-positive success entries for a scrape that produced no JobPost.

**Fix in agents PR #21**: new module-level \`format_scrape_label(entry_id, final_id)\` renders \"entry→final\" when they differ, \"entry\" otherwise. Applied to the \"graph done\" log, the graph-cap timeout warning, and the graph-exception log.

Closes the \`Hold-poller graph done log uses entry-time scrape_id (false-positive success on parent)\` inbox TODO.

## Test plan

- [x] 4 new unit tests for \`format_scrape_label\` + 27 adjacent scrape-graph tests pass locally
- [x] \`ruff check\` clean on agents changes
- [x] agents PR #21 merged at 1872a62
- [ ] Manual on prod: trigger a redirecting scrape (LinkedIn /uas/login, ZipRecruiter /km/) and verify logfire shows \`Scrape <parent>→<child> graph done\`