### PR TITLE
fix: collapse ZipRecruiter URL variants in dedupe

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -41,7 +41,11 @@ Archive (1)
 - Submodule scope on entry headings goes in proper org tags (=:frontend:=, =:api:=, =:ai:=, =:bug:=), NOT bracket-suffix annotations like =[frontend]=. Tags stack: =:frontend:bug:=. Don't bulk-rewrite historical =[frontend]= entries.
 ** TODO capture prompt used.
 ** TODO new user, no wizard on localhost:4200
-** TODO ZipRecruiter dedup gaps — three URL shapes for the same job  :scrape:dedupe:bug:
+** DONE ZipRecruiter dedup gaps — three URL shapes for the same job :scrape:dedupe:bug:
+CLOSED: [2026-05-12 Tue 18:21]
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-12]
+:END:
 Repro: jp 1908 (source=email, /km/<opaque>), jp 1923 (source=extension, /jobs/altus-llc-2287a4f5/software-developer-c-remote-2ffd5d4c?lk=…&tsid=…), jp 1924 (source=extension, /jobs/altus-llc/software-developer-c-remote?lvk=…). Same Altus Engineering C++ Software Developer role. canonical_link == link on all three (canonicalize_link is a no-op for ZipRecruiter — no profile rewrites, no tracking-param strip).
 
 Three distinct gaps, fix in priority order:
@@ -62,6 +66,21 @@ Files:
 Smallest test once #1+#2 land: =test_scrape_from_text.py= case where jp exists at /jobs/altus-llc-<token>/<jobslug>-<token>?lk=… and a new submission lands at /jobs/altus-llc/<jobslug>?lvk=…; assert 409 with =meta.job_post_id= pointing at existing.
 
 Out of scope: SQL re-pointing of =duplicate_of_id= for 1908/1923/1924 — user handles via SQL. /km/ resolution at cc_auto email-parse time is its own follow-up.
+
+*** What shipped
+- =api/job_hunting/models/job_post_dedupe.py= — added =lk=, =lvk=, =tsid= to =_TRACKING_PARAMS=. Closes gap #1.
+- =api/job_hunting/tests/test_job_post_dedupe.py= — unit tests for the new tracking-param strip + the ZipRecruiter rewrite (collapse + no-token-passthrough). Tests fixture the ScrapeProfile inline so they prove the dedup pipeline end-to-end against the gap-#2 rule.
+- =api/job_hunting/tests/test_scrape_from_text.py= — integration test: tokenized existing JP + clean-variant submission → 409 =duplicate_job_post=, no Scrape created, no agent call.
+- =api/job_hunting/management/commands/recanonicalize_job_posts.py= — operator-invoked backfill that re-applies canonicalize_link to every JobPost. Run after the post-deploy MCP rule update so legacy rows pick up both gap fixes.
+
+*** Operator follow-ups (NOT in this PR)
+- Run =update_scrape_profile= MCP for =ziprecruiter.com= adding rule:
+  =match=: =/jobs/([^/]+?)-([a-f0-9]{8})/([^/?#]+?)-([a-f0-9]{8})(?=[/?#]|$)=
+  =rewrite=: =/jobs/\1/\3=
+  Profile data is operator-owned JSONB, deliberately not put behind a code migration.
+- After the MCP edit lands, run =python manage.py recanonicalize_job_posts= once to backfill =canonical_link= on existing rows.
+
+Gap #3 (=/km/<opaque>= email redirects) deliberately left for a cc_auto follow-up.
 ** TODO When Clicking on possible duplicate link, the resulting job-post is the duplicate but the possible duplicate warning never chagnes to the other d
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-08]


### PR DESCRIPTION
## Summary

Inbox: `ZipRecruiter dedup gaps — three URL shapes for the same job`. Three submission shapes for the same job were producing three JobPost rows because `canonicalize_link` was a no-op for ziprecruiter.com.

| repo | commit | what |
|------|--------|------|
| api  | overcast-software/career_caddy_api#113 (06783fb) | `_TRACKING_PARAMS` += `lk`/`lvk`/`tsid`; `recanonicalize_job_posts` management command; unit + integration tests |
| parent | this PR | api pin + todo.org (DONE + what shipped + operator follow-ups) |

## Operator follow-ups (post-merge, NOT in this PR)

1. `update_scrape_profile` MCP for `ziprecruiter.com` — add rule `match: /jobs/([^/]+?)-([a-f0-9]{8})/([^/?#]+?)-([a-f0-9]{8})(?=[/?#]|$)`, `rewrite: /jobs/\\1/\\3`. Operator-owned JSONB, deliberately not in a code migration.
2. `python manage.py recanonicalize_job_posts` once to backfill `canonical_link` on existing rows.

## Out of scope

- Gap #3 (`/km/<opaque>` email-redirect tokens) — needs cc_auto-side redirect resolution.
- SQL re-pointing of `duplicate_of_id` for jp 1908/1923/1924 — user-handled.

## Test plan

- [x] `make ci` green locally: api 854/854, frontend 346/346, both lints clean.