### PR TITLE
fix: three inbox STRTs (frontend pin)

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -45,7 +45,18 @@ Archive (1)
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-08]
 :END:
-** TODO skeleton pages in reports
+** DONE skeleton pages in reports :frontend:
+CLOSED: [2026-05-12]
+=reports/activity/loading.hbs= used the generic =<LoadingSkeleton />=
+(eight-card list) which doesn't match the calendar+stacked-chart
+shape of the live page. The peer loading templates
+(=application-flow/loading.hbs= + =sources/loading.hbs=) already
+render a chart-shaped pulse panel; activity was the odd one out.
+
+What shipped (frontend submodule):
+- =frontend/app/templates/reports/activity/loading.hbs= — heading +
+  tall pulse panel for the calendar + medium pulse for the optional
+  stacked-status chart. Matches the existing chart-shaped pattern.
 ** TODO https://chromewebstore.google.com/detail/career-caddy-sender/pjdajamkhjkemoaogohehcdpfkocofhd
 ** TODO Extension API-key sprawl: dedupe on Connect or auto-expire server-side
 Each popup Connect mints a fresh =Career Caddy Sender — YYYY-MM-DD= key; Disconnect best-effort revokes. Leaks happen on uninstall, profile reset, or offline disconnect. Severity is low — keys are scoped to the minting user — but the API-keys list grows unbounded.
@@ -70,13 +81,35 @@ Root cause (per user): the scrape pipeline does not click through ATS chains (Se
 Secondary: fingerprint-based dedupe also missed despite ~95% identical description text. Worth checking why.
 
 Fix surfaces: agents scrape graph (ATS click-through), api dedupe pipeline (fingerprint match strength). Not an extension bug.
-** TODO score spinner not standard
+** DONE score spinner not standard :frontend:
+CLOSED: [2026-05-12]
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
 :END:
+=components/job-posts/actions.js:128= called
+=spinner.wrap(newScore.save(), { label: 'Scoring, please wait…' })=
+— verbose outlier vs. the codebase standard of terse labels
+(=Scoring…=, =Parsing…=, =Generating cover letter…=, etc.).
+
+What shipped (frontend submodule):
+- =frontend/app/components/job-posts/actions.js= — label normalized
+  to ='Scoring…'= matching the standard pattern.
 ** TODO delete -> delete everything should scroll to section with popup.
 job-post.show.delete
-** TODO ai chat display context for user.  user confused about context.
+** DONE ai chat display context for user.  user confused about context. :frontend:chat:
+CLOSED: [2026-05-12]
+=chat.service.js= sends =page_context: this.currentPage.url= to the
+server on every turn (=services/chat.js:128=) but =Chat::Panel= UI
+never showed it — the user couldn't tell what context the AI knows
+about, leading to confused "wait, do you know what page I'm on?"
+loops.
+
+What shipped (frontend submodule):
+- =frontend/app/components/chat/panel.hbs= — small "Context: <url>"
+  strip below the panel header (link icon + monospaced URL) showing
+  =chat.currentPage.url=. Tooltip explains the AI sees this URL on
+  every turn. Renders only when =currentPage.url= is set so empty
+  routes don't show a stub strip.
 ** TODO buy me coffee.  cofee leaderborad :frontend:
 ** TODO Vertical slide animation for jp.show.questions index <-> detail :frontend:
 :PROPERTIES:


### PR DESCRIPTION
## Summary

Bumps frontend to `b5ecc3a` ([frontend PR #146](https://github.com/overcast-software/career_caddy_frontend/pull/146)). Three independent inbox STRT items, bundled because each is a small isolated edit.

| commit | submodule | what |
|---|---|---|
| `b5ecc3a` | frontend | three commits: chart-shaped activity skeleton, normalized score-spinner label, chat panel page-context strip |

## Test plan

- [x] `make ci` green locally (api 854/854, frontend 346/346)
- [ ] Manual browser pass after merge