### PR TITLE
feat: bump frontend pin — Firefox extension, docs page, docs scroll fix

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -183,9 +183,15 @@ Tags: docs, infra
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
 :END:
+*** SHIPPED SHIPPED Firefox extension support + browser-extension docs page :frontend:extension: 
+CLOSED: [2026-05-13 Wed 08:40]
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-13]
+:END:
+Closed [2026-05-13]: Firefox add-on listing went live alongside the Chrome Web Store entry, so the install CTA in frontend/app/services/extension-install.js now returns =available: true= for Firefox UAs with the AMO URL. Added a new docs page at /docs/extension (frontend/app/routes/docs/extension.js + controllers/docs/extension.js + templates/docs/extension.hbs) covering install, first-time connect, sending posts, the auto-score toggle, the 1.1.1 Resend-to-complete UX, and disconnect. Linked from the docs index Resources table. Also: wizard/score.hbs copy de-Chrome-d to "browser extension" since both stores are live. Bonus: fixed scroll-to-top on docs sub-route transitions — RouteLayout scrolls inside .course-main not window, so docs.js now resets .course-main.scrollTop on every docs.* routeDidChange (was landing mid-page when clicking links from the long docs index).
 *** TODO remove expand caret on sidebar
 :PROPERTIES:
-:LAST_TOUCHED: [2026-05-08]
+:LAST_TOUCHED: [2026-05-13]
 :END:
 remove the expand carrot on the sidebar
 *** TODO Profile-as-resource: split User/Profile JSON:API conformity :api:frontend:chore:

--- a/todo.org_archive
+++ b/todo.org_archive
@@ -7305,3 +7305,26 @@ CLOSED: [2026-05-13 Wed 08:25]
 :ARCHIVE_TODO: DONE
 :ARCHIVE_ITAGS: IMPORTANT
 :END:
+
+* TODO https:  careercaddy.online job-posts 985 job-applications
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-04]
+:ARCHIVE_TIME: 2026-05-13 Wed 08:39
+:ARCHIVE_FILE: ~/Network/syncthing/Projects/career_caddy/todo.org
+:ARCHIVE_OLPATH: Inbox
+:ARCHIVE_CATEGORY: todo
+:ARCHIVE_TODO: TODO
+:ARCHIVE_ITAGS: IMPORTANT
+:END:
+what jp.show.job-application.show
+
+* TODO https:  careercaddy.online job-posts 1551
+:PROPERTIES:
+:ARCHIVE_TIME: 2026-05-13 Wed 08:39
+:ARCHIVE_FILE: ~/Network/syncthing/Projects/career_caddy/todo.org
+:ARCHIVE_OLPATH: Inbox
+:ARCHIVE_CATEGORY: todo
+:ARCHIVE_TODO: TODO
+:ARCHIVE_ITAGS: IMPORTANT
+:END:
+why two canonical?


### PR DESCRIPTION
## Summary
Bumps the frontend submodule pin to pick up Firefox install support, a new \`/docs/extension\` page, and a scroll-to-top fix for docs sub-route transitions.

| commit | submodule | what |
|--------|-----------|------|
| 7cf36507 | frontend | Firefox AMO URL in \`extension-install\` service, new \`/docs/extension\` page (route + controller + template), browser-agnostic wizard copy, \`.course-main\` scroll-to-top on \`docs.*\` transitions, get-started acceptance test accepts either store origin |

## Test plan
- [x] frontend PR #150 merged; \`make ci\` green pre-merge (api 869/869, frontend 350/350)
- [ ] post-deploy: confirm /docs/extension renders, install CTA matches the browser, and scrolling docs links reset to top