### PR TITLE
fix: bump frontend pin — list-model cache discards destroyed records

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -179,6 +179,8 @@ Background context: came up while discussing how non-Emacs contributors would us
 
 Tags: docs, infra
 *** TODO capture prompt used. :medium:
+*** TODO make pills so flex can stack nicely on mobile :frontend:
+https://www.hyperui.dev/components/application/tabs/#component-5-dark
 ** Enhancement
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-05]
@@ -422,9 +424,20 @@ controllers/job-posts/show/questions.js were deleted before ship.
 :END:
 Untriaged. Run =(cc-todo-triage)= to autoroute high-confidence entries; low-confidence ones stay here with a =:TRIAGE_NOTE:= drawer.
 
+*** SHIPPED list-model cache held destroyed records — login broken in prod :frontend: 
+CLOSED: [2026-05-13 Wed 09:58]
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-13]
+:END:
+Closed [2026-05-13]: After logout (=store.unloadAll=) or per-record =destroyRecord=, the cached =InfinityModel= in =frontend/app/utils/list-model.js= still held references to destroyed records. On next visit the template walked an =@belongsTo= async proxy whose target was gone — Ember Data threw =Cannot read properties of undefined (reading '_graph')= in prod (Chromium), Glimmer threw =Cannot create a new tag for `<(unknown):emberNNN>` after it has been destroyed= in dev (Firefox). Symptom: only the FIRST row in =/job-posts= rendered. Fix: =infinityModel()= now also discards the cache when any cached record is =isDestroyed= or =isDestroying=. Architecture note: =Architecture/list-model.js cache — list-route InfinityModel + destroyed-record invalidation=. Punted side effect tracked separately as =Inbox/Bug/stagger-rows replays after logout-and-back...=
+*** TODO stagger-rows replays after logout-and-back or row delete on list pages :frontend: 
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-13]
+:END:
+Narrow regression introduced by the destroyed-record invalidation in =frontend/app/utils/list-model.js= (shipped 2026-05-13). When the cached =InfinityModel= holds destroyed records — happens after logout/login or after =record.destroyRecord()= — the cache is invalidated, the DOM is rebuilt, and the =stagger-rows= entry animation replays from row 1. Reads as a full page reload. Normal tab nav between list routes is unaffected; cache hits + animation stays suppressed. Defer; users can not log in is the higher priority. Architecture note: =Architecture/list-model.js cache — list-route InfinityModel + destroyed-record invalidation= for full context.
 *** TODO Logout/login shows another user's score
 :PROPERTIES:
-:LAST_TOUCHED: [2026-05-08]
+:LAST_TOUCHED: [2026-05-13]
 :END:
 After logout + login as the same user, the popup (or app?) displayed a score belonging to a different user. Possible causes: (1) frontend Ember Data store not cleared on logout — stale records from previous session leak into new one; (2) UX7 made filter[link] visible across users — popup-open lookup may resolve to another user's JobPost id, then pull THAT user's score; (3) backend score endpoint not properly user-scoped. Repro: log out, log in, observe score visible that does not belong to current user. PRIORITY: privacy / auth bug. Investigate before promoting CWS Unlisted listing.
 *** TODO [#A] frontend scrapes.show does not follow redirect chain to surface canonical JobPost
@@ -545,22 +558,6 @@ Projects
 {% endif %}
 * Active :IMPORTANT:
 Work that should happen. Categories carry =[done/total]= cookies.
-
-** TODO https:  careercaddy.online job-posts 1667 scrapes 309 :scrape:
-https://www.ziprecruiter.com/jobs/v2/eyJsaXN0aW5nX2tleSI6InIzTzNkcWV2TUMyU3NEci1GNkQ4MGciLCJtYXRjaF9pZCI6IjAxOWRlZjM5LWY2YmEtNzY5Yy1iMWQwLTA0YWYyMmNjYzc4MSIsImJpZF90cmFja2luZ19kYXRhIjoiQUFHM3lPbGhZOWlVbEZlVTI3X3BkTk5HNFNRRkFaeHVPOVhESmo2VTdldE1Tb1ZyVXV1UXc0UV9mMWRreHBJcnNNQW9maWFMIiwic291cmNlX3BsYWNlbWVudF9pZCI6NDMwMjR9?tsid=111000153
-The graph trace actually shows DetectObstacle completed quickly (29ms) and routed to ResolveFinalUrl — so the scrape moved past DetectObstacle. The issue is it's now stuck in ResolveFinalUrl and the overall status is still running.
-
-This looks like the scrape is hanging after navigating the ZipRecruiter tracking/redirect URL. A few things to note:
-
-    The URL is a ZipRecruiter tracking link (/km/...) with an auth_token and expires timestamp — the token expired on May 5, 2026, so this URL may no longer be valid, which could cause the redirect/resolution to hang or fail silently.
-    The scrape has been stuck in running since ~18:12 UTC — that's well past a normal timeout window.
-
-What I'd recommend:
-
-    Check if the original job posting URL (not the tracking link) is available — a direct ZipRecruiter job URL (e.g. ziprecruiter.com/jobs/...) would be much more reliable.
-    If you have the direct URL, we can update the scrape or create a new one with that link instead.
-
-Do you have the direct job post link, or would you like me to check the job post (ID 1667) for any other URL we can use?
 
 ** TODO Ingest abuse defense — Phase 2 (provenance + pipeline) :api:agents:security:scrape:
 Phase 2 follow-up. Single deliverable for vector I5
@@ -705,7 +702,7 @@ I should be taken to job-post.show.scrapes.show
 however I had to go to job-post.show.scrapes.index and I did not see my scrape there
 I refreshed the page and saw it then in "hold"
 when it completed, I had to reload the page to see the updated job-post.description
-** TODO Scrape diagnostic panel on  scrapes <id> :frontend:scrape:
+** TODO [#C] Scrape diagnostic panel on  scrapes <id> :frontend:scrape:
 :PROPERTIES:
 :CREATED: [2026-04-30]
 :END:
@@ -786,8 +783,6 @@ feeds the eventual plugin PR.
 
 ** IDEA Flash message slide-wipe transition :frontend:
 Queue sequential display instead of stacking. First flash finishes its time, slides left, next slides in.
-** TODO make pills so flex can stack nicely on mobile :frontend:
-https://www.hyperui.dev/components/application/tabs/#component-5-dark
 ** TODO tiny button to go to  companies <id> :frontend:
 ** TODO Reports: applies-by-hostname cut on sources sankey :tier6:frontend:
 Add an "applies-by-hostname" cut on the sources sankey distinct


### PR DESCRIPTION
## Summary
Bumps frontend pin to pick up the list-route render fix.

| commit | submodule | what |
|--------|-----------|------|
| db420042 | frontend | \`infinityModel()\` discards cache when any cached record is \`isDestroyed\`/\`isDestroying\`. Fixes /job-posts (and every list route — companies, scrapes, summaries, etc.) rendering only the first row after logout-and-back-in or row delete. |

## Test plan
- [x] frontend PR #151 merged; \`make ci\` green pre-merge (api 869/869, frontend 350/350)
- [ ] post-deploy: log out → log in → /job-posts renders the full list