### PR TITLE
chore: bump Dagger to v0.20.8 + aggressive prune on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: true
 
       - name: Install Dagger CLI
-        run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.3 BIN_DIR=/usr/local/bin sh
+        run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.8 BIN_DIR=/usr/local/bin sh
 
       - name: Build and test API
         run: dagger -m ./dagger call build-api

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: true
 
       - name: Install Dagger CLI
-        run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.3 BIN_DIR=/usr/local/bin sh
+        run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.8 BIN_DIR=/usr/local/bin sh
 
       - name: Build and test API
         run: dagger -m ./dagger call build-api
@@ -42,7 +42,7 @@ jobs:
           submodules: true
 
       - name: Install Dagger CLI
-        run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.3 BIN_DIR=/usr/local/bin sh
+        run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.8 BIN_DIR=/usr/local/bin sh
 
       - name: Publish images to GHCR
         run: |

--- a/dagger/dagger.json
+++ b/dagger/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "career-caddy",
-  "engineVersion": "v0.20.3",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "python"
   },

--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -449,7 +449,13 @@ class CareerCaddy:
                     f"docker compose -f docker-compose.prod.yml pull; "
                     f"docker compose -f docker-compose.prod.yml down --remove-orphans; "
                     f"docker compose -f docker-compose.prod.yml up -d --remove-orphans; "
-                    f"docker image prune -f",
+                    # Reclaim disk: prune unused images (including OLD per-SHA
+                    # tags from previous deploys, not just dangling ones),
+                    # stopped containers, and unused networks. Equivalent to
+                    # the manual `docker system prune -a` the operator was
+                    # running by hand. Volumes are intentionally excluded —
+                    # the Postgres data volume must survive.
+                    f"docker system prune -a -f",
                 ]
             )
             .stdout()


### PR DESCRIPTION
## Summary
Parent-only infra tweaks. No submodule changes.

| change | file | what |
|--------|------|------|
| Dagger bump | \`dagger/dagger.json\`, \`.github/workflows/ci.yml\`, \`.github/workflows/deploy.yml\` | engineVersion + CI installer v0.20.3 → v0.20.8. Aligns with the v0.20.8 already running locally. |
| Aggressive deploy prune | \`dagger/src/career_caddy_pipeline.py\` | \`docker image prune -f\` → \`docker system prune -a -f\`. Removes old per-SHA image tags + stopped containers + unused networks. Volumes preserved. Eliminates the daily manual \`docker system prune -a\` the operator was running. |

## Why no \`make ci\`?
Neither change runs in \`make ci\` — the dagger version pin is config-only, and the deploy step is invoked from the Deploy workflow (which fires on this merge).

## Test plan
- [ ] Merge triggers Deploy workflow with v0.20.8 installer
- [ ] Deploy step runs \`docker system prune -a -f\` cleanly (no interactive prompt hang)
- [ ] Disk usage on rn drops; no need to manually prune for ~deploy cycle