### PR TITLE
fix: bump frontend pin — model-derived spinner gate

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -424,6 +424,13 @@ controllers/job-posts/show/questions.js were deleted before ship.
 :END:
 Untriaged. Run =(cc-todo-triage)= to autoroute high-confidence entries; low-confidence ones stay here with a =:TRIAGE_NOTE:= drawer.
 
+*** TODO from-text inline scorer span detached from parent request :api:agents: 
+Diagnosing the JP 2045 description-clobber required pulling a gpt-5 scorer span (id 4254ad0101bf8519) whose =parent_span_id= was null even though it was kicked off inline by =POST /scrapes/from-text/=. Naive logfire trace queries by trace_id miss it; you have to widen by user/time. This hid the score-vs-extract ordering on the from-text path and matters anytime we investigate any score/extract race on extension-sourced scrapes. Fix shape: when =/scrapes/from-text/= triggers the inline scorer, propagate the request's span context so the scorer span attaches to its parent. Affects =api/job_hunting/api/views/scrapes.py= from-text handler + the scorer kickoff. Verification: a new from-text POST should show the scorer span as a child of the request span in logfire. 
+*** TODO linkedin.com extraction_hints overfires on rich extension captures :scrape:extension: 
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-13]
+:END:
+ScrapeProfile id=2 (linkedin.com) =extraction_hints= emits =[DESCRIPTION NOT CAPTURED]= whenever ="Use AI to assess how you fit"= appears followed by ="Looking for talent?"=. That gate is correct for Camoufox poller partial-hydration captures (added 2026-05-03) but misfires on EVERY cc_sender extension capture of a LinkedIn jobs/view page — top card always carries the AI button, LinkedIn footer always carries ="Looking for talent?"=, and the full description sits BETWEEN them. The rule is presence-only and never measures body length / absence-of-description tokens. Concrete repro: JP 2045 / scrape 422 — Stripe Backend/API Engineer, ~9KB cc_sender capture, scorer correctly scored 82 from =Scrape.job_content= but extractor wrote the placeholder into =JobPost.description=. Fix shape: tighten extraction_hints to require body between company-name and LinkedIn-footer is <~500 chars OR contains NONE of {Responsibilities, Qualifications, About the job, What you'll do, Who you are, Minimum Requirements} BEFORE emitting the placeholder. Belt-and-suspenders: =parse_scrape= should bypass the partial-render heuristic when =scrape.source = 'extension'=. Verification: re-run =parse_scrape= against scrape 422 post-fix; JP 2045 description should land as the real Stripe body, not the placeholder. Architecture note exists in =Operations/Scrape Log= [2026-05-13 14:35]. 
 *** SHIPPED list-model cache held destroyed records — login broken in prod :frontend:
 CLOSED: [2026-05-13 Wed 09:58]
 :PROPERTIES:


### PR DESCRIPTION
## Summary
Bumps frontend pin to pick up the spinner gate refactor.

| commit | submodule | what |
|--------|-----------|------|
| ee027f44 | frontend | Switch list-row spinner gate from session-scoped \`pollable.pendingIds\` to model-derived \`isPending\` getter on score/cover-letter/summary/scrape. F5 + server-kicked-off records now show their spinner correctly; original cross-contamination bug stays fixed via per-record gate. |

## Test plan
- [x] frontend PR #154 merged; \`make ci\` green pre-merge (api 869/869, frontend 349/349)
- [x] Manual (user-verified): cold reload on /job-posts/X/scores shows spinner for pending scores