### PR TITLE
feat: API_HOST build-arg + dagger plumbing + healthcheck fail-open

### DIFF
--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -358,6 +358,7 @@ class CareerCaddy:
         org: str = "overcast-software",
         tag: str = "latest",
         registry_username: str = "",
+        frontend_api_host: str = "https://api.careercaddy.online",
     ) -> list[str]:
         """Build all images and push to GHCR. Returns list of pushed image refs.
 
@@ -366,6 +367,9 @@ class CareerCaddy:
             org: GitHub organization (used in image path)
             tag: Image tag (use git SHA for immutable tags)
             registry_username: GitHub actor username for GHCR auth (defaults to org)
+            frontend_api_host: API origin baked into the frontend production
+                build. Matches the frontend/Dockerfile ARG default. Pass an
+                empty string for same-origin (proxy in front of both apps).
         """
         username = registry_username or org
         api_ref = f"{REGISTRY}/{org}/{API_IMAGE}:{tag}"
@@ -381,7 +385,7 @@ class CareerCaddy:
 
         pushed_frontend = await (
             frontend_src
-            .docker_build()
+            .docker_build(build_args=[dagger.BuildArg("API_HOST", frontend_api_host)])
             .with_registry_auth(REGISTRY, username, registry_token)
             .publish(frontend_ref)
         )


### PR DESCRIPTION
## Summary

| commit | submodule | what |
|---|---|---|
| frontend PR #162 (3a57872) | `frontend` | Dockerfile ARG API_HOST + env.js drop hardcode + health.js fail-open |
| 48d55c3 | parent | `dagger publish()` gains `--frontend-api-host` arg; bump frontend pointer |

Replaces the JS-side hardcoded prod API URL with a Dockerfile `ARG API_HOST` threaded through the Dagger pipeline. Prod publishes are byte-identical — defaults at every layer equal the old hardcoded value. Dev/preview images can now opt into same-origin (or any other API origin) via `--frontend-api-host=""` without code changes.

Also fixes the healthcheck silent-lockout: if the API is unreachable during bootstrap, the frontend now fails open (`/setup` remains reachable) instead of caching `bootstrapOpen=false` and trapping first-run users on the login screen.

## Test plan

- [x] `make ci` green: frontend QUnit 332/332, api `Ran 896 tests OK`, lint clean on both.
- [ ] After merge, the Deploy workflow's `dagger call publish` (no override) bakes `https://api.careercaddy.online` into the prod frontend image — sanity-check via the resulting GHCR image.

## Follow-up

Separate commit on the `dev` branch will pass `--frontend-api-host=""` in `.github/workflows/deploy-dev.yml` so the pibu `:dev` arm64 frontend bakes empty → same-origin (paired with the pibu agent's Caddy `/api/*` reverse-proxy, tracked in `notes.org` at `Architecture/Same-origin /api/* routing for dev frontend on pibu`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)