### PR TITLE
feat: same-origin frontend default (pin prod via deploy.yml)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,12 +45,16 @@ jobs:
         run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.8 BIN_DIR=/usr/local/bin sh
 
       - name: Publish images to GHCR
+        # --frontend-api-host pins prod to cross-origin (api.careercaddy.online).
+        # When prod's outer Caddy gains a /api/* path rule, drop this flag and
+        # the same-origin default takes over.
         run: |
           dagger -m ./dagger call publish \
             --registry-token=env:GHCR_TOKEN \
             --org=overcast-software \
             --tag=${{ github.sha }} \
-            --registry-username=${{ github.actor }}
+            --registry-username=${{ github.actor }} \
+            --frontend-api-host=https://api.careercaddy.online
         env:
           GHCR_TOKEN: ${{ github.token }}
 

--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -358,7 +358,7 @@ class CareerCaddy:
         org: str = "overcast-software",
         tag: str = "latest",
         registry_username: str = "",
-        frontend_api_host: str = "https://api.careercaddy.online",
+        frontend_api_host: str = "",
     ) -> list[str]:
         """Build all images and push to GHCR. Returns list of pushed image refs.
 
@@ -368,8 +368,9 @@ class CareerCaddy:
             tag: Image tag (use git SHA for immutable tags)
             registry_username: GitHub actor username for GHCR auth (defaults to org)
             frontend_api_host: API origin baked into the frontend production
-                build. Matches the frontend/Dockerfile ARG default. Pass an
-                empty string for same-origin (proxy in front of both apps).
+                build. Default is empty → same-origin (SPA emits /api/v1/...;
+                outer proxy routes /api/* to the api container). Pass a full
+                origin only for explicit cross-origin deployments.
         """
         username = registry_username or org
         api_ref = f"{REGISTRY}/{org}/{API_IMAGE}:{tag}"


### PR DESCRIPTION
## Summary
| Commit | Submodule | What |
|---|---|---|
| `85af6a7` | frontend | `Dockerfile` `ARG API_HOST=""` default → same-origin Ember production build |
| `ec8ad04` | parent   | bump frontend pin + flip dagger `frontend_api_host` default + pin prod cross-origin in `deploy.yml` |

## Why
The dev frontend on pibu (`careercaddy.dev`) was issuing CORS preflights to the prod API hostname (`https://api.careercaddy.online/api/v1/initialize`). The fix is to make same-origin the build default so SPA paths emit `/api/v1/...` and an outer proxy routes `/api/*` to the api container.

Making same-origin the default means new deployments are correct by default; cross-origin is now opt-in via `--frontend-api-host=https://...`.

## Production safety
Prod's outer Caddy does not yet have a `/api/*` path rule, so flipping the default everywhere would break prod's next deploy. To prevent that, `deploy.yml` explicitly passes `--frontend-api-host=https://api.careercaddy.online`. Prod stays cross-origin until the Caddy rule lands; then drop the flag for a clean cutover.

`deploy-dev.yml` (on the `dev` branch) is unchanged — it picks up the new empty default, which is what pibu actually wants.

## Test plan
- [x] `make ci` green locally — api 896/896, frontend 332/332.
- [x] Frontend PR #163 merged (`85af6a7`).
- [ ] After this merge, FF `main` → `dev` so the deploy-dev workflow rebuilds `:dev` with the new default.
- [ ] Pibu agent: `handle_path /api/*` Caddy rule + `make pull-pibu` on pibu.
- [ ] Verify `https://careercaddy.dev/api/v1/healthcheck` returns same-origin (no CORS preflight to `api.careercaddy.online`).