### PR TITLE
chore: bump api — cross-platform apply_url reciprocity in find_duplicate

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -694,9 +694,20 @@ https://www.hyperui.dev/components/application/tabs/#component-5-dark
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-15]
 :END:
+*** SHIPPED find_duplicate catches cross-platform apply_url reciprocity
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-26]
+:END:
+Promote the apply_url-reciprocity signal from compute_duplicate_candidates (presentation only) into find_duplicate (decision-time). Cross-platform duplicates where one JP's apply_url points at another JP's link now collapse at create time instead of being only surfaced as a post-create hint banner.
+
+Concrete repro: JP 2882 (wellfound.com listing) had apply_url=pindrop.com/.../?gh_jid=7943713. ccsender (extension) later POSTed JP 2923 with link=pindrop.com/.../?gh_jid=7943713 — byte-identical to 2882.apply_url — and 2923 was created as new because find_duplicate only checked canonical_link (different domains) and content_fingerprint (locations differed: "Remote only • United States" vs "United States").
+
+Shape: api/job_hunting/models/job_post_dedupe.py gains find_apply_url_matches(post, base_qs=None), a private-ish primitive returning a distinct queryset across both reciprocity directions. find_duplicate calls it as stage 2 (between canonical_link and fingerprint). api/job_hunting/api/serializers.py compute_duplicate_candidates replaces its inline apply_url filter with the same helper — single source of truth for the apply_hint signal.
+
+Follow-up: existing JP pairs (like 2882/2923) are not retroactively merged. Manual cleanup or a one-off backfill is a separate task.
 *** TODO extension/ccsender-structured-prefill — pull css_selectors at submit time :extension:scrape:agents:
 :PROPERTIES:
-:LAST_TOUCHED: [2026-05-20]
+:LAST_TOUCHED: [2026-05-26]
 :PRIORITY: P2
 :END:
 Today ccsender posts =body.innerText= and the api LLM re-extracts everything from scratch — even on hosts where =ScrapeProfile.css_selectors.job_data= already names where title/company/location/salary/description live. Since the extension now fetches the profile on send anyway (=GET /scrape-profiles/extension-selectors/=), it is trivial to also ship =css_selectors.job_data= in the same response and have the extension run those selectors in the active tab.


### PR DESCRIPTION
## Summary

| commit | repo | what |
|---|---|---|
| [e7e3c3d](https://github.com/overcast-software/career_caddy_api/commit/e7e3c3d) (api PR #126) | api | `find_duplicate` gains stage 2 apply_url reciprocity check via shared `find_apply_url_matches` primitive; `compute_duplicate_candidates` uses the same helper |

Resolves the JP 2882 / 2923 cross-platform dedupe miss: a jobboard JP whose `apply_url` points at an ATS direct link now collapses on creation instead of producing a separate row that only the post-create "possible duplicates" panel surfaces.

## Test plan

- [x] `make ci` green locally: api 906/906, frontend 332/332, lint clean
- [x] Focused: `test_job_post_dedupe` 32/32 (10 new), `test_job_post_duplicate_candidates` 15/15 (presentation path preserved), `test_job_post_resolve_and_dedupe` 7/7
- [ ] Post-deploy sanity: future ccsender submission of a URL byte-identical to an existing JP's `apply_url` should not produce a new row