### PR TITLE
chore(deploy): drop --frontend-api-host so prod frontend ships same-origin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,16 +45,16 @@ jobs:
         run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.8 BIN_DIR=/usr/local/bin sh
 
       - name: Publish images to GHCR
-        # --frontend-api-host pins prod to cross-origin (api.careercaddy.online).
-        # When prod's outer Caddy gains a /api/* path rule, drop this flag and
-        # the same-origin default takes over.
+        # Frontend builds with API_HOST="" (same-origin default). The SPA
+        # emits /api/v1/... to its own host; racknerd's outer Caddy routes
+        # /api/* on careercaddy.online to the api container via the
+        # handle /api/* label on the frontend service.
         run: |
           dagger -m ./dagger call publish \
             --registry-token=env:GHCR_TOKEN \
             --org=overcast-software \
             --tag=${{ github.sha }} \
-            --registry-username=${{ github.actor }} \
-            --frontend-api-host=https://api.careercaddy.online
+            --registry-username=${{ github.actor }}
         env:
           GHCR_TOKEN: ${{ github.token }}
 

--- a/todo.org
+++ b/todo.org
@@ -768,7 +768,17 @@ https://www.hyperui.dev/components/application/tabs/#component-5-dark
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-15]
 :END:
+*** SHIPPED deploy.yml — drop --frontend-api-host flag for same-origin prod
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-27]
+:END:
+Removed --frontend-api-host=https://api.careercaddy.online from .github/workflows/deploy.yml Publish step. Next prod rebuild bakes API_HOST="" (same-origin default from frontend/Dockerfile). SPA will emit /api/v1/... to its own host; racknerd Caddy frontend label caddy.handle: /api/* routes those to the api container, preserving the /api prefix for Django.
+
+Pairs with racknerd ansible playbook change that added the handle label + careercaddy.online to ALLOWED_HOSTS default. Verified pre-ship via curl https://careercaddy.online/api/v1/healthcheck/ returning 200.
 *** TODO cc_auto inline-post mailto link from verified recruiter email
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-27]
+:END:
 Today: JP 2914 (Ruby on Rails Developer, source=email_direct, link=null) prompted a fix attempt at career_caddy_automation/scripts/inbox_triage.py _create_inline_job_post — parse the email out of InlinePostResult.recruiter_contact (which the LLM is prompted to emit as "Name <email>" or "Name <email> | phone"), build link=mailto:<email>, pass to the api. Reverted before commit: user's principle is "rather blank than wrong" — an unverified LLM-extracted email could send Apply traffic to a fabricated address, which is worse than the current blank-link state. Same family of concern as the parent's Inbox/job_post_extractor prompt anti-hallucination salary rules followup (drop bad fields per-field; don't trust LLM output for fields with real downstream impact).
 
 Blocker: independent verification surface. The orchestrator scripts/inbox_triage.py only has EmailMeta (id/subject/tags/thread_id) in scope — no From: header, no raw body. To verify the parsed mailto address against the source, the orchestrator needs either:


### PR DESCRIPTION
## Summary

Removes the explicit `--frontend-api-host=https://api.careercaddy.online` override from the Publish step in `.github/workflows/deploy.yml`. Next prod rebuild bakes `API_HOST=""` into the Ember production build (same-origin default in `frontend/Dockerfile`), so the SPA emits `/api/v1/...` to its own host.

## Why now

Racknerd's outer Caddy was just taught to handle `/api/*` on `careercaddy.online` (frontend container labels: `caddy.handle: /api/*` + `caddy.handle.reverse_proxy: api:8000`), and the api container's `ALLOWED_HOSTS` default now includes `careercaddy.online`. Pre-ship verification:

```
curl -sS -o /dev/null -w "%{http_code}\n" https://careercaddy.online/api/v1/healthcheck/
# → 200
```

`api.careercaddy.online` keeps its own site block from the api container's labels, so the agent traffic (CC_API_TOKEN flow) stays live as a separate route — no breaking change for cc_auto / extension API key consumers.

## Test plan

- [x] Pre-ship: same-origin `/api/v1/healthcheck/` returns 200 on prod
- [ ] Post-deploy: open careercaddy.online in incognito, confirm DevTools Network panel shows `/api/v1/...` requests going to `careercaddy.online` (same origin) and not `api.careercaddy.online`
- [ ] Verify no CORS preflights on the SPA's first load
- [ ] Confirm agent/MCP traffic against `api.careercaddy.online` still works (unchanged)