### PR TITLE
chore: bump api — resume favorite read-only attr fix

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -1039,9 +1039,12 @@ controllers/job-posts/show/questions.js were deleted before ship.
 :END:
 Untriaged. Run =(cc-todo-triage)= to autoroute high-confidence entries; low-confidence ones stay here with a =:TRIAGE_NOTE:= drawer.
 
+*** SHIPPED Resume favorite PATCH 500 from effective_section_order property setter
+CLOSED: [2026-05-27]
+Logfire showed AttributeError: property effective_section_order of Resume object has no setter on PATCH /api/v1/resumes/{25,36}/ at 15:10Z 2026-05-27. Cause: ResumeSerializer.attributes lists effective_section_order (read field) but read_only_attributes is empty, so BaseSerializer.parse_payload round-trips the value back to setattr. Frontend Ember Data PATCH includes every declared @attr on save, so favorite toggle (resume.save) trips it every time. Fix: add read_only_attributes = [effective_section_order] in api/job_hunting/api/serializers.py ResumeSerializer; new regression test test_patch_ignores_effective_section_order in api/job_hunting/tests/test_resume.py mimicking the real Ember Data PATCH payload. api 924/924 pass, ruff clean.
 *** TODO sweep_stuck_scoring cron — paired with model.isPending gate
 :PROPERTIES:
-:LAST_TOUCHED: [2026-05-20]
+:LAST_TOUCHED: [2026-05-27]
 :END:
 Now that the spinner gate reads =status= directly off the record (per-model =isPending= getter, shipped 2026-05-13), a Score / CoverLetter / Summary / Scrape that gets stuck in a non-terminal state on the server (worker dies mid-flight, OOM, exception bypasses the =finally=) will spin forever in the UI on every visit. We already have =sweep_stuck_extracting= for Scrape; need the equivalent for Score (and probably CoverLetter / Summary). Two-prong: (1) wrap the worker entrypoints in =try / except / finally= that ALWAYS sets a terminal status, (2) periodic management command (cron) that flips records older than N minutes in pending states to =error= with a reason. Surfaces as =/api/v1/sweep_stuck_<resource>/= mgmt commands; runs on the api container schedule. Should mirror =sweep_stuck_extracting= shape exactly so ops behavior is consistent.
 *** TODO from-text inline scorer span detached from parent request :api:agents:


### PR DESCRIPTION
## Summary

Hotfix for prod bug: every PATCH to `/api/v1/resumes/:id/` 500s with `AttributeError: property 'effective_section_order' has no setter`. Favorite toggles on resumes have been broken — Ember Data's `resume.save()` round-trips every declared `@attr`, including the computed `effective_section_order`, and the api blindly setattr's it.

| commit | submodule | what |
|---|---|---|
| api → e6242ed | [#128](https://github.com/overcast-software/career_caddy_api/pull/128) | `read_only_attributes = ["effective_section_order"]` on ResumeSerializer + regression test pinning real Ember Data PATCH shape |

## Test plan

- [x] `make ci` green — api 924/924 (was 923 + 1 regression), frontend 336/336, lint clean.
- [ ] Post-deploy: open a resume in prod, click the star to favorite, confirm 200 + UI updates without flash error.
- [ ] Post-deploy: Logfire arbitrary_query for `effective_section_order` AttributeError shows zero new occurrences over the next hour.