### PR TITLE
chore: bump api — strip url trailing junk on JobPost save

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -1039,6 +1039,9 @@ controllers/job-posts/show/questions.js were deleted before ship.
 :END:
 Untriaged. Run =(cc-todo-triage)= to autoroute high-confidence entries; low-confidence ones stay here with a =:TRIAGE_NOTE:= drawer.
 
+*** SHIPPED URL trailing junk in JobPost.link from LLM extractor breaks apply hrefs
+CLOSED: [2026-05-27]
+2026-05-27 hiring.cafe JP 2981: link stored as https://hiring.cafe/job/5fsbbgitg82ev1ar with trailing double-quote that the LLM URL extractor in career_caddy_automation pulled from the HTML attribute. Frontend URL-encoded the quote to %22 and hiring.cafe 404 since the slug literally included %22. Fix: new strip_url_trailing_junk helper in api/job_hunting/models/job_post_dedupe.py strips trailing HTML/markdown delimiter slop ([quote, apostrophe, less/greater, parens, brackets, braces, backtick, comma, whitespace]) from URLs. canonicalize_link calls it first, JobPost.save sanitizes link and apply_url before storage. Migration 0079 backfills existing rows. 9 new tests cover the helper, canonicalize_link integration, and save-time scrub.
 *** TODO sweep_stuck_scoring cron — paired with model.isPending gate
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-27]


### PR DESCRIPTION
## Summary

Hotfix for the JP 2981 hiring.cafe apply-link 404 — the LLM URL extractor in cc_auto captured the closing `\"` from an HTML attribute, the api stored it, the frontend URL-encoded it to `%22` in the href, hiring.cafe couldn't find the slug.

| commit | submodule | what |
|---|---|---|
| api → 78df93a | [#129](https://github.com/overcast-software/career_caddy_api/pull/129) | `strip_url_trailing_junk` helper, JobPost.save sanitizes link + apply_url, canonicalize_link strips first, migration 0079 backfills existing rows |

## Test plan

- [x] `make ci` green — api 933/933 (+9 helper tests), frontend 336/336, lint clean.
- [ ] Post-deploy: open JP 2981 on careercaddy.online, click the apply link, confirm hiring.cafe now resolves (the migration should have cleaned the stored link on first run).
- [ ] Post-deploy: Logfire — no new 4xx on hiring.cafe URLs ending in `%22` over the next hour.