### PR TITLE
chore: bump api + add worker service — Job-queue Phase 1

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -77,6 +77,52 @@ services:
       retries: 3
     mem_limit: 512m
 
+  # ── Worker ──────────────────────────────────────────────────────────────
+  # django-q2 task worker — Phase 1 of Plans/Job-queue integration. Shares
+  # the api image (same SHA, same code, same env) so a tagged deploy moves
+  # api + worker together. No HTTP surface; consumes django_q_ormq off the
+  # same Postgres DB. No behavior change in Phase 1 — only the
+  # `health_check` task is wired in. Subsequent phases migrate the 9
+  # daemon-thread spawn points + 2 polling daemons (hold-poller
+  # atomic-deleted in Phase 4).
+  worker:
+    image: ghcr.io/overcast-software/career_caddy_api:${IMAGE_TAG:-latest}
+    restart: unless-stopped
+    entrypoint: ""
+    command: python manage.py qcluster
+    environment:
+      DEBUG: "False"
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
+      DATABASE_URL: postgresql://${DB_USER:-postgres}:${DB_PASSWORD}@db:5432/${DB_NAME:-job_hunting}
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-api.careercaddy.online,localhost,127.0.0.1,worker}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      SCRAPING_ENABLED: ${SCRAPING_ENABLED:-False}
+      SA_SCHEMA_ON_POST_MIGRATE: "False"  # api runs migrations; worker just consumes
+      USE_MCP_BROWSER_AGENT: "False"
+      CHAT_SERVICE_URL: "http://chat:8000"
+      EMAIL_BACKEND: ${EMAIL_BACKEND:-django.core.mail.backends.smtp.EmailBackend}
+      EMAIL_HOST: ${EMAIL_HOST:?EMAIL_HOST is required}
+      EMAIL_PORT: ${EMAIL_PORT:-587}
+      EMAIL_HOST_USER: ${EMAIL_HOST_USER:?EMAIL_HOST_USER is required}
+      EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD:?EMAIL_HOST_PASSWORD is required}
+      EMAIL_USE_TLS: ${EMAIL_USE_TLS:-True}
+      DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-noreply@careercaddy.online}
+      FRONTEND_URL: ${FRONTEND_URL:-https://careercaddy.online}
+      SCREENSHOT_DIR: /app/screenshots
+      LOGFIRE_TOKEN: ${LOGFIRE_TOKEN:-}
+      CAREER_CADDY_INSTANCE: ${CAREER_CADDY_INSTANCE:-careercaddy.online}
+    volumes:
+      - screenshots:/app/screenshots
+    depends_on:
+      db:
+        condition: service_healthy
+      api:
+        # api owns the migration run on boot; worker waits for it to be
+        # at least started before trying to qcluster against the queue
+        # tables.
+        condition: service_started
+    mem_limit: 384m
+
   frontend:
     image: ghcr.io/overcast-software/career-caddy-frontend:${IMAGE_TAG:-latest}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,51 @@ services:
       db:
         condition: service_healthy
 
+  # ── Worker ──────────────────────────────────────────────────────────────
+  # django-q2 task worker — Phase 1 of Plans/Job-queue integration. Shares
+  # the api image (same code, same venv, same env). Runs `manage.py qcluster`
+  # to consume the django_q_ormq queue table off the same Postgres DB. No
+  # behavior change in Phase 1 — only the `health_check` task is wired in.
+  # Subsequent phases migrate the 9 daemon-thread spawn points + 2 polling
+  # daemons (hold-poller atomic-deleted in Phase 4).
+  worker:
+    build:
+      context: ./api
+    entrypoint: ""
+    command: python manage.py qcluster
+    volumes:
+      - ./api:/app
+      - api_venv:/app/.venv
+      - screenshots:/app/screenshots
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@db:5432/${DB_NAME:-job_hunting}
+      DEBUG: "True"
+      SECRET_KEY: ${SECRET_KEY:-dev-only-insecure-do-not-use-in-production}
+      # Worker doesn't serve HTTP, but Django still wants ALLOWED_HOSTS
+      # set when running management commands in some configurations.
+      ALLOWED_HOSTS: "localhost,127.0.0.1,worker"
+      USE_MCP_BROWSER_AGENT: "${USE_MCP_BROWSER_AGENT:-False}"
+      BROWSER_MCP_SSE_URL: "http://browser-mcp:3004/sse"
+      CHAT_SERVICE_URL: "http://chat:8000"
+      SCREENSHOT_DIR: /app/screenshots
+      EMAIL_BACKEND: ${EMAIL_BACKEND:-django.core.mail.backends.console.EmailBackend}
+      EMAIL_HOST: ${EMAIL_HOST:-}
+      EMAIL_PORT: ${EMAIL_PORT:-587}
+      EMAIL_HOST_USER: ${EMAIL_HOST_USER:-}
+      EMAIL_HOST_PASSWORD: ${EMAIL_HOST_PASSWORD:-}
+      EMAIL_USE_TLS: ${EMAIL_USE_TLS:-True}
+      DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-noreply@localhost}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:4200}
+    depends_on:
+      db:
+        condition: service_healthy
+      api:
+        # Wait for api to come up so it can run migrations first; the
+        # worker can't qcluster a database whose django_q_* tables
+        # don't exist yet.
+        condition: service_started
+
   frontend:
     image: node:20-slim
     working_dir: /app


### PR DESCRIPTION
## Summary

| commit | submodule | PR | what |
|---|---|---|---|
| \`fdebd47\` | api | [#133](https://github.com/overcast-software/career_caddy_api/pull/133) | Phase 1 — django-q2 plumbing, no behavior change |

Adds the \`worker\` service to both \`docker-compose.yml\` (dev) and \`docker-compose.prod.yml\`. Shares the api image (same SHA, same env) so a tagged prod deploy moves api + worker together. Runs \`manage.py qcluster\`; no HTTP surface.

Phase 1 of Plans/Job-queue integration — django-q2 phased rollout. Worker only consumes the smoke-test \`health_check\` task at this stage; subsequent phases migrate the 9 daemon-thread spawn points + 2 polling daemons (hold-poller atomic-deleted in Phase 4).

## Test plan
- [x] \`docker compose up worker\` boots qcluster cleanly in dev
- [x] Enqueued \`health_check\` task completes within 3s, returns expected payload
- [x] \`make ci\` clean (api 982 / frontend 342)