### PR TITLE
chore: bump api — Phase 3 Cover Letter/Answer/Resume on django-q2

### DIFF
--- a/todo.org
+++ b/todo.org
@@ -478,7 +478,7 @@ shows up in the Phase 6 failed-task surface (Phase 6 must ship before
 Phase 4 or basic visibility is missing — see plan).
 
 *Out of scope*: parse_scrape (Phase 5), score_poller (Phase 5).
-*** TODO Job-queue Phase 3 — Cover Letter, Answer, Question, Resume migrations
+*** DONE Job-queue Phase 3 — Cover Letter, Answer, Question, Resume migrations
 :PROPERTIES:
 :CREATED: [2026-05-30]
 :CANONICAL: Plans/Job-queue integration — django-q2 phased rollout


### PR DESCRIPTION
## Summary

Bumps api pin to pick up [api #135](https://github.com/overcast-software/career_caddy_api/pull/135) — three more `threading.Thread` spawn points migrated to qcluster worker tasks.

| submodule | PR | what |
|-----------|----|------|
| api | [#135](https://github.com/overcast-software/career_caddy_api/pull/135) | `cover_letter_job` + `answer_job` + `resume_parse_job`; 4 threading sites gone (includes resume's 5-min timeout wrapper, now owned by Q_CLUSTER.timeout) |

## Test plan

- [x] `make ci` green pre-push (api 982 tests, frontend 350/350)
- [ ] Deploy workflow green post-merge