### PR TITLE
feat: add automation/ as fourth submodule (cc_auto operator-side)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "agents"]
 	path = agents
 	url = git@github.com:overcast-software/career_caddy_agents.git
+[submodule "automation"]
+	path = automation
+	url = git@github.com:overcast-software/career_caddy_automation.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Structure
 
-Three independently deployable submodules, each with its own `CLAUDE.md`:
+Four independently deployable submodules, each with its own `CLAUDE.md`:
 
 - `frontend/` — Ember.js 6.x SPA (see `frontend/CLAUDE.md`)
 - `api/` — Django REST Framework backend (see `api/CLAUDE.md` — not yet created)
-- `agents/` — Pydantic-AI agents + MCP servers + browser scraper + hold-poller (see `agents/CLAUDE.md`)
+- `agents/` — service-side: Pydantic-AI agents + MCP servers + browser scraper + pollers (see `agents/CLAUDE.md`)
+- `automation/` — operator-side: email triage + caddy-web + A2A orchestrator + link traverser (see `automation/CLAUDE.md`)
 
-Inside the `agents/` submodule, top-level peer folders advertise the heterogeneity:
+### `agents/` vs `automation/` — service vs operator
+
+The two are split by who they serve:
+
+- **`agents/` = server-side, service-driven.** Runs as Docker containers for *everyone*: Camoufox + Playwright browser, `scrape_graph` pydantic-graph state machine, prod MCP servers (`chat_server.py` + `public_server.py` shipped to `:8031` + `:8030`), pollers (`hold_poller.py`, `score_poller.py` — both retiring via the django-q2 phased rollout). When the queue migration lands, the scrape worker container also lives here because it needs Camoufox.
+- **`automation/` = user-side, operator-driven.** Runs on *one user's* machines (laptop, pibu, home server). Email triage pipeline (`scripts/inbox_triage.py` + `src/email_source/` + `src/email_classifier/`), caddy-web copilot, A2A orchestrator, link traverser, sharpen_profiles. **HTTP-only contract** with the api + public MCP — no Python imports cross. Self-hosters set `CC_API_BASE_URL` / `CC_MCP_URL` / `CC_API_TOKEN` and point at their own Career Caddy domain.
+
+Test: *service for everyone* → `agents/`; *operator for one user* → `automation/`.
+
+### Inside `agents/`
+
+Top-level peer folders advertise the heterogeneity:
 
 - `agents/agents/` — Pydantic-AI agent definitions (the spine: job_extractor, obstacle, onboarding, career_caddy CRUD)
 - `agents/mcp_servers/` — Four MCP servers; `chat_server.py` and `public_server.py` ship to prod (`:8031` chat, `:8030` public at `mcp.careercaddy.online`); `browser_server.py` and `career_caddy_server.py` are local-only
@@ -19,10 +31,6 @@ Inside the `agents/` submodule, top-level peer folders advertise the heterogenei
 - `agents/pollers/` — long-running daemons (`hold_poller.py`, `score_poller.py`)
 - `agents/tools/` — one-shot operator scripts (`manual_login`, `discover_sites`, `export_graph_structure`, `fetch_chromium`)
 - `agents/lib/` — shared utilities (`api_tools.py` HTTP client, `toolsets.py`, `models/`, `history.py`, etc.)
-
-### Sibling consumer (not a submodule)
-
-`~/Network/syncthing/Projects/career_caddy_automation/` ("cc_auto") is a sibling toolkit for email triage and other workflows that drives Career Caddy entirely over HTTP — no Python imports cross the boundary. Self-hosters set the `CC_API_BASE_URL` / `CC_MCP_URL` / `CC_API_TOKEN` env trio and point cc_auto at their own Career Caddy domain.
 
 ## Getting Started (Full Local Dev)
 

--- a/todo.org
+++ b/todo.org
@@ -95,6 +95,78 @@ Some changes touch multiple repos (e.g. API contract change ripples into fronten
 - New UI components must use Tailwind utilities following HyperUI patterns. Never custom CSS.
 - Use hyperui, tailwind, and defined color palettes when writing UI html.
 - Submodule scope on entry headings goes in proper org tags (=:frontend:=, =:api:=, =:ai:=, =:bug:=), NOT bracket-suffix annotations like =[frontend]=. Tags stack: =:frontend:bug:=. Don't bulk-rewrite historical =[frontend]= entries.
+** DONE [cc_auto] Phase 1 complete — ready for =git submodule add automation/= [2026-05-30] :cc_auto:shared-contract:
+CLOSED: [2026-05-30 Sat]
+:PROPERTIES:
+:LAST_TOUCHED: [2026-05-30]
+:HANDOFF_TO: cc-orchestrator
+:SIGNAL_LOCATION: career_caddy_automation/notes.org "Phase 1 complete — ready for parent submodule-add [2026-05-30]"
+:REMOTE: git@github.com:overcast-software/career_caddy_automation.git
+:PIN: df7fdf1 (origin/main HEAD; cc-auto's stated 6ddbe8d was orphaned by a subsequent public-prep rebase, but df7fdf1 contains the equivalent Phase 1 content under rewritten SHAs plus the LICENSE bootstrap)
+:CONSUMED_BY: parent feature/automation-submodule [2026-05-30]
+:END:
+
+cc-auto agent has finished the seven Phase 1 sub-items in
+=career_caddy_automation/todo.org/Phase 1 — repo-side prep for automation/
+submodule conversion=. Repo is in shippable shape; remote pushed.
+
+Five commits landed on
+=github.com:overcast-software/career_caddy_automation main=:
+
+| sub-item | commit    | summary                                                          |
+|----------+-----------+------------------------------------------------------------------|
+| 1.1      | =4b66614= | =.gitignore= picks up =.ok= scratch file                         |
+| 1.3      | =2f8cb97= | =Makefile= with =ci= / =lint= / =fmt= / =test= targets           |
+| 1.4      | =d1379a8= | =CLAUDE.md= refreshed: operator-side framing, Mongo, =make ci=   |
+| 1.6      | =f1642b8= | =scripts/hold_poller.py= deleted (stopgap; canonical at agents/) |
+| 1.7      | =571293b= | =todo.org= DONE-marking; ack-back signal in notes.org            |
+
+Verified-clean (no diff needed):
+
+- 1.2 Gitflow — =feature/* → main=, =init.defaultBranch=main=, no
+  =develop= references anywhere.
+- 1.5 Agent description — =~/.claude/agents/cc-auto.md= edited
+  outside the repo tree: drops "standalone sibling" framing, documents
+  the role split (operator vs. service), points at the new
+  =claude/ca-*= emacsclient helpers in
+  =~/.config/doom/lisp/career_caddy_auto.el=.
+
+*Verification*: =make ci= passes (17 tests + ruff check). =git status=
+clean on tracked files (only =notes.org= modified — local-only per
+memory).
+
+*cc-orchestrator's Phase 2+ to do*:
+
+1. =git submodule add git@github.com:overcast-software/career_caddy_automation.git automation/=
+   in the parent worktree (SSH per Q1 lean; matches =agents/=).
+2. =.gitmodules= update; initial pin = =6ddbe8d= (cc_auto main HEAD
+   at ack-back, includes LICENSE merge from origin's bootstrap
+   commit).
+3. Parent =CLAUDE.md= updated to list =automation/= alongside
+   =api/= / =frontend/= / =agents/=.
+4. =agents/CLAUDE.md= updated with the role-split cross-link
+   (service = =agents/= containers, operator = =automation/= user-side
+   orchestration; full text in =notes.org Plans/Promoting cc_auto →
+   automation/.../Role split=).
+5. =dagger/src/career_caddy_pipeline.py= — add =lintAutomation= and
+   =testAutomation= functions calling =make ci= from inside
+   =automation/=.
+6. =Makefile= top-level — add =lint-automation= + =test-automation=
+   targets; roll into =make ci-all= behind which =make ci= adds
+   automation gradually.
+
+*Open follow-ups that do NOT block Phase 2*:
+
+- The =cc_auto= Roadmap (catchall email + link traversal + pibu log
+  surfacing + queue alignment) lives at
+  =career_caddy_automation/notes.org/PROJ Roadmap…=. Phase A (Mongo
+  observability + file logs) starts after the conversion lands.
+- *Phase D2 (worker image prep) is superseded* — per the role split,
+  the django-q2 worker stays in =agents/=; =automation/= is not a
+  worker host.
+- =src/db.py= (SQLite shim from commit e26f787) is still in the tree;
+  deleted alongside the Mongo introduction in Phase A1.
+
 ** TODO [cc_auto] Roadmap landed: catchall mail + link traversal + pibu + log surfacing — needs api+ops coordination [2026-05-30] :cc_auto:api:ops:
 :PROPERTIES:
 :LAST_TOUCHED: [2026-05-30]


### PR DESCRIPTION
## Summary

Promotes cc_auto from a sibling toolkit at `~/Network/syncthing/Projects/career_caddy_automation/` to the fourth parent submodule at path `automation/`. Aligns with the operator-vs-service role split documented in `notes.org/Plans/Promoting cc_auto → automation/ — first-class submodule`. Resolves the cc-auto agent's Phase 1 handoff signal in `todo.org`.

## Pin choice

`df7fdf1` (origin/main HEAD).

cc-auto's stated pin `6ddbe8d` was orphaned by a subsequent `chore(public-prep)` rebase on the cc_auto remote that consolidated the LICENSE bootstrap and stripped personal paths. `df7fdf1` contains the same Phase 1 content under rewritten SHAs (`.gitignore .ok` / `Makefile` / `CLAUDE.md` refresh / `scripts/hold_poller.py` deletion / `todo.org` DONE-marking) plus the LICENSE and the public-prep cleanup.

## Parent CLAUDE.md

New "agents/ vs automation/" section makes the boundary explicit:

- **agents/** = server-side service-driven (Docker containers for everyone)
- **automation/** = user-side operator-driven (runs on one user's machines, HTTP-only contract)

Test: *service for everyone* → `agents/`; *operator for one user* → `automation/`.

## Test plan

- [x] `git submodule add` resolves cleanly; `.gitmodules` entry + gitlink staged
- [x] Pin resolves to `df7fdf1` (verified reachable on `origin/main`)
- [x] Parent `CLAUDE.md` lists four submodules with role-split documentation
- [x] cc-auto handoff todo entry marked DONE with `:CONSUMED_BY:` property pointing at this PR
- [ ] Deploy workflow unaffected post-merge (this PR adds a submodule but does not yet wire it into any build; that's Phase 3)

## Out of scope (separate PRs)

- `agents/CLAUDE.md` cross-link to the role split (submodule change — small)
- Dagger `lintAutomation` + `testAutomation` functions and Makefile `lint-automation` / `test-automation` targets (Phase 3)