### PR TITLE
ci: wire automation/ (cc_auto) into Dagger + Makefile (Phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,9 @@ make migrate          # run Django migrations
 make demo-data        # seed guest user (Danny Noonan) + demo data (run after migrate)
 make test-api         # run API test suite
 make test-frontend    # run Ember QUnit tests
-make ci               # Dagger: lint + test API and frontend locally
+make test-automation  # run automation (cc_auto) pytest suite
+make lint-automation  # ruff-check automation (cc_auto)
+make ci               # Dagger: lint + test API + frontend + automation locally
 make ci-ai            # Dagger: build slim AI image (no camoufox)
 make scrape-url URL=https://...   # scrape one job URL → add to Career Caddy
 make poller                          # hold-poller against prod (Camoufox default)
@@ -166,15 +168,17 @@ curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
 
 **Run locally** (no secrets needed — Dagger uses its own Docker sidecar):
 ```bash
-make ci           # lint + test API and frontend
+make ci           # lint + test API + frontend + automation
 make ci-ai        # build AI image (slow first run, downloads camoufox)
 ```
 
 **Available Dagger functions:**
 ```bash
-dagger -m ./dagger call build-api       # lint + test API (spins up postgres sidecar)
-dagger -m ./dagger call build-frontend  # lint + test frontend
-dagger -m ./dagger call build-ai        # build AI image with camoufox
+dagger -m ./dagger call build-api          # lint + test API (spins up postgres sidecar)
+dagger -m ./dagger call build-frontend     # lint + test frontend
+dagger -m ./dagger call lint-automation    # ruff-check automation (cc_auto)
+dagger -m ./dagger call test-automation    # pytest in automation (cc_auto)
+dagger -m ./dagger call build-ai           # build AI image with camoufox
 dagger -m ./dagger call publish --registry-token=env:GITHUB_TOKEN --org=overcast-software --tag=latest
 dagger -m ./dagger call deploy --ssh-key=file:~/.ssh/id_ed25519 --host=<vps> --app-dir=/opt/career-caddy --tag=latest
 ```

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 -include .env.local
 export
 
-.PHONY: up up-core up-full down logs build shell-api shell-db migrate test-api test-frontend bootstrap ci ci-ai scrape-url doctor doctor-poller list help
+.PHONY: up up-core up-full down logs build shell-api shell-db migrate test-api test-frontend test-automation lint-api lint-frontend lint-automation format-frontend bootstrap ci ci-ai scrape-url doctor doctor-poller list help
 
 # ── Dev stack ──────────────────────────────────────────────────────────────
 
@@ -75,6 +75,16 @@ lint-frontend: ## Prettier-check frontend (PATHS=... for files; defaults to whol
 format-frontend: ## Prettier auto-fix frontend (PATHS=... for files; defaults to whole tree)
 	docker compose exec frontend npm run lint:format -- --write $(if $(PATHS),$(PATHS),.)
 
+# automation/ doesn't have a long-running container in compose, so its
+# lint/test run via `uv run --group dev ...` directly (matches its own
+# Makefile contract). Quick iteration loop; the Dagger functions
+# below are the pre-push gate.
+lint-automation: ## Ruff-lint automation (cc_auto) code
+	$(MAKE) -C automation lint
+
+test-automation: ## Run pytest in automation (cc_auto)
+	$(MAKE) -C automation test
+
 # ── CI (Dagger) ────────────────────────────────────────────────────────────
 # Requires Dagger CLI: curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
 #
@@ -85,13 +95,17 @@ format-frontend: ## Prettier auto-fix frontend (PATHS=... for files; defaults to
 # between the lint and test functions, so the split is not duplicated work.
 
 .PHONY: ci ci-lint ci-test
-.PHONY: ci-lint-api ci-lint-frontend ci-test-api ci-test-frontend
+.PHONY: ci-lint-api ci-lint-frontend ci-lint-automation
+.PHONY: ci-test-api ci-test-frontend ci-test-automation
 
 ci-lint-api:
 	dagger -m ./dagger call lint-api
 
 ci-lint-frontend:
 	dagger -m ./dagger call lint-frontend
+
+ci-lint-automation:
+	dagger -m ./dagger call lint-automation
 
 # Concise reports: surface failure blocks + summary; suppress dagger noise.
 # Pass FULL=1 to dump the entire test log unfiltered.
@@ -121,12 +135,27 @@ ci-test-frontend:
 		'; \
 	fi
 
-ci-lint: ci-lint-api ci-lint-frontend
-ci-test: ci-test-api ci-test-frontend
+ci-test-automation:
+	@set -o pipefail; \
+	if [ -n "$(FULL)" ]; then \
+		dagger -m ./dagger call test-automation stdout 2>&1; \
+	else \
+		dagger -m ./dagger call test-automation stdout 2>&1 | awk ' \
+			/^FAILED / { hit=1; n=15; print; next } \
+			/^ERROR / { hit=1; n=15; print; next } \
+			/====+ FAILURES ====+/ { hit=1; n=40; print; next } \
+			/====+ ERRORS ====+/ { hit=1; n=40; print; next } \
+			/[0-9]+ (passed|failed|error|skipped|deselected|warning)/ { print } \
+			hit { print; if (n-- <= 0) hit=0 } \
+		'; \
+	fi
 
-ci: ## Run API + frontend CI checks locally via Dagger (lint then tests, parallel within each phase)
-	$(MAKE) -j2 ci-lint
-	$(MAKE) -j2 ci-test
+ci-lint: ci-lint-api ci-lint-frontend ci-lint-automation
+ci-test: ci-test-api ci-test-frontend ci-test-automation
+
+ci: ## Run API + frontend + automation CI locally via Dagger (lint then tests, parallel within each phase)
+	$(MAKE) -j3 ci-lint
+	$(MAKE) -j3 ci-test
 
 ci-ai: ## Build the slim AI Docker image via Dagger (no camoufox — production image)
 	dagger -m ./dagger call build-ai

--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -68,6 +68,36 @@ class CareerCaddy:
             .with_exec(["uv", "sync", "--frozen"])
         )
 
+    def _automation_base(self, src: dagger.Directory) -> dagger.Container:
+        # automation/ (cc_auto) is operator-side Python: uv + pymongo +
+        # pytest. No browser, no Camoufox, no postgres — its tests
+        # monkeypatch `_db_or_none` so they don't hit a real Mongo.
+        # Mirrors `_api_base`'s shape; the only diff is no libpq.
+        src = (
+            src
+            .without_directory(".venv")
+            .without_directory(".git")
+            .without_directory("var")
+        )
+        return (
+            dag.container()
+            .from_("python:3.11-slim")
+            .with_exec(
+                [
+                    "sh", "-c",
+                    "apt-get update && apt-get install -y --no-install-recommends "
+                    "make curl && rm -rf /var/lib/apt/lists/*",
+                ]
+            )
+            .with_exec(["pip", "install", "uv"])
+            .with_workdir("/app")
+            .with_file("/app/pyproject.toml", src.file("pyproject.toml"))
+            .with_file("/app/uv.lock", src.file("uv.lock"))
+            .with_exec(["uv", "sync", "--frozen", "--no-install-project", "--group", "dev"])
+            .with_directory("/app", src)
+            .with_exec(["uv", "sync", "--frozen", "--group", "dev"])
+        )
+
     def _frontend_base(self, src: dagger.Directory) -> dagger.Container:
         src = (
             src
@@ -122,6 +152,16 @@ class CareerCaddy:
     ) -> dagger.Container:
         """eslint + prettier + ember-template-lint + stylelint. No tests."""
         return self._frontend_base(src).with_exec(["npm", "run", "lint"])
+
+    @function
+    async def lint_automation(
+        self,
+        src: Annotated[dagger.Directory, DefaultPath("../automation")],
+    ) -> dagger.Container:
+        """Ruff check on the automation (cc_auto) source. Uses cc_auto's
+        Makefile entry point so cc-auto agent's contract stays canonical:
+        whatever `make lint` runs locally is what CI runs."""
+        return self._automation_base(src).with_exec(["make", "lint"])
 
     # ── Tests-only (slow) ──────────────────────────────────────────────────
 
@@ -205,6 +245,41 @@ class CareerCaddy:
                 "cat /tap.log; "
                 "grep -qE '^# fail +0$' /tap.log "
                 "&& grep -qE '^# pass +[1-9]' /tap.log",
+            ])
+        )
+
+    @function
+    async def test_automation(
+        self,
+        src: Annotated[dagger.Directory, DefaultPath("../automation")],
+    ) -> dagger.Container:
+        """pytest against automation (cc_auto). Tests monkeypatch the
+        Mongo client — no postgres / mongo sidecar required."""
+        return (
+            self._automation_base(src)
+            # Tee pytest output to /test.log so the assertion below can
+            # verify the canonical "N passed in Ms" summary. pipefail
+            # propagates pytest's exit through `tee`.
+            .with_exec([
+                "bash", "-c",
+                "set -o pipefail; "
+                "make test 2>&1 | tee /test.log",
+            ])
+            # Belt-and-suspenders: require the canonical pytest success
+            # summary in the log. Guards against "exit 0 with zero tests
+            # collected" (would not match `\d+ passed`) and against any
+            # failed/error lines slipping through. Matches the api +
+            # frontend lint-then-test split's assertion style.
+            #
+            # Cat the log first so `dagger call test-automation stdout`
+            # returns the test output (otherwise the grep-q exec is
+            # silent and downstream filters have nothing to chew on).
+            .with_exec([
+                "sh", "-c",
+                "cat /test.log; "
+                "grep -qE '[0-9]+ passed' /test.log "
+                "&& ! grep -qE '[0-9]+ failed' /test.log "
+                "&& ! grep -qE '[0-9]+ error' /test.log",
             ])
         )
 


### PR DESCRIPTION
## Summary

Phase 3 of `Plans/Promoting cc_auto → automation/`. Adds CI gating for the `automation/` submodule so `make ci` covers all four.

## Dagger functions added

- `_automation_base` — `python:3.11-slim` + `uv` + `uv sync --group dev`. No libpq, no Camoufox, no postgres sidecar; automation/'s tests monkeypatch `_db_or_none` and don't touch real Mongo.
- `lint_automation` — calls cc_auto's `make lint` (ruff). The Makefile entry point in `automation/` is the contract.
- `test_automation` — calls `make test` (pytest) under tee + pipefail; belt-and-suspenders grep on the canonical pytest summary lines. Mirrors the api+frontend split's assertion style.

## Makefile additions

- `lint-automation` / `test-automation` — thin `$(MAKE) -C automation` wrappers.
- `ci-lint-automation` / `ci-test-automation` — Dagger invocations with the awk-filter style matching existing api+frontend rules.
- `make ci` now runs all three submodules in parallel (`-j3`). Promoted from the planned `ci-all`-behind-a-flag gate because cc_auto's `make ci` is 0.96s locally / 2.63s in Dagger; no reason to defer.

## Verification

Local `make ci`:
- automation: **37 passed in 2.63s**
- frontend: **350/350 pass**
- api: **982 tests OK**

## Test plan

- [x] `make ci` green across all four submodules
- [x] `dagger -m ./dagger call lint-automation` resolves and runs
- [x] `dagger -m ./dagger call test-automation` resolves and runs
- [x] Parent `CLAUDE.md` lists the new Make targets + Dagger functions
- [ ] Deploy workflow unaffected post-merge (CI surface change only)