### PR TITLE
fix(dagger): drop explicit down on deploy; let up -d --remove-orphans recreate

### DIFF
--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -527,7 +527,14 @@ class CareerCaddy:
                     f"cd {app_dir}; "
                     f"grep -q '^IMAGE_TAG=' .env && sed -i 's/^IMAGE_TAG=.*/IMAGE_TAG={tag}/' .env || echo 'IMAGE_TAG={tag}' >> .env; "
                     f"docker compose -f docker-compose.prod.yml pull; "
-                    f"docker compose -f docker-compose.prod.yml down --remove-orphans; "
+                    # No explicit `down` — `up -d --remove-orphans` recreates
+                    # only containers whose resolved image/config changed
+                    # (app services, because IMAGE_TAG just moved). The db
+                    # service uses unparameterized postgres:18 so it stays
+                    # running, which (a) gives us zero db downtime and (b)
+                    # avoids the docker-proxy host-port re-bind race that
+                    # broke deploys when down+up ran back-to-back without
+                    # the proxy fully releasing 127.0.0.1:5432 in between.
                     f"docker compose -f docker-compose.prod.yml up -d --remove-orphans; "
                     # Reclaim disk: prune unused images (including OLD per-SHA
                     # tags from previous deploys, not just dangling ones),


### PR DESCRIPTION
## Summary

Five consecutive Deploys failed with:

> `Bind for 127.0.0.1:5432 failed: port is already allocated`

at the `up -d` step that immediately follows `down --remove-orphans` in the dagger `deploy()` shell chain. The `down` log shows db cleanly stopped/removed and the network gone before `up` runs, so nothing application-side is holding the port. Root cause is the **docker-proxy** userland helper not fully releasing 127.0.0.1:5432 between containers being removed and the new ones being scheduled — a known timing race when down+up run back-to-back via a single shell invocation. Doug's manual \`docker compose down && docker compose up\` on the VPS doesn't hit it because the human-pause between commands gives the proxy time to release.

## Fix

Skip the explicit `down`. `docker compose up -d --remove-orphans` on a stack that's already up already recreates exactly the containers whose resolved image/config changed:

- App services (api, frontend, chat, mcp, worker) — `IMAGE_TAG` just moved, so they're recreated.
- db service — image is `postgres:18` (unparameterized), so it stays running and the host-port binding never moves.

That eliminates the host-port re-bind cycle entirely. Bonus: zero db downtime per deploy. `--remove-orphans` still clears services removed from the compose file. The `docker system prune -a -f` step continues to reclaim old per-SHA image tags.

## Test plan

- [ ] Parent CI green (no behavior change to the build steps).
- [ ] Once merged, Deploy lands on the VPS without the port-bind error.
- [ ] `POST /api/v1/scrapes/claim-next/` returns 200/204 (not 405) → pibu's runner can finally claim work.
- [ ] db container's uptime survives the deploy (`docker inspect career_caddy-db-1 --format '{{.State.StartedAt}}'` unchanged).