### PR TITLE
fix(dagger): deploy — restore down, wait for 5432 to free, pkill zombie fallback

### DIFF
--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -527,14 +527,24 @@ class CareerCaddy:
                     f"cd {app_dir}; "
                     f"grep -q '^IMAGE_TAG=' .env && sed -i 's/^IMAGE_TAG=.*/IMAGE_TAG={tag}/' .env || echo 'IMAGE_TAG={tag}' >> .env; "
                     f"docker compose -f docker-compose.prod.yml pull; "
-                    # No explicit `down` — `up -d --remove-orphans` recreates
-                    # only containers whose resolved image/config changed
-                    # (app services, because IMAGE_TAG just moved). The db
-                    # service uses unparameterized postgres:18 so it stays
-                    # running, which (a) gives us zero db downtime and (b)
-                    # avoids the docker-proxy host-port re-bind race that
-                    # broke deploys when down+up ran back-to-back without
-                    # the proxy fully releasing 127.0.0.1:5432 in between.
+                    f"docker compose -f docker-compose.prod.yml down --remove-orphans; "
+                    # docker-proxy can outlive the container that spawned it
+                    # by a few hundred ms after `down` returns; chaining `up`
+                    # immediately makes the new db container fail with
+                    # `Bind for 127.0.0.1:5432 failed: port is already
+                    # allocated`. Manual `down` then `up` typed at a shell
+                    # doesn't hit it because the human-pause is enough.
+                    # Poll until the port frees (≤30s), then fall back to
+                    # an explicit pkill if a true zombie is hanging on.
+                    f"for i in $(seq 1 30); do "
+                    f"  ss -tnl 'sport = :5432' 2>/dev/null | grep -q ':5432' || break; "
+                    f"  sleep 1; "
+                    f"done; "
+                    f"if ss -tnl 'sport = :5432' 2>/dev/null | grep -q ':5432'; then "
+                    f"  echo 'WARN: 5432 still bound after 30s, pkill docker-proxy fallback'; "
+                    f"  pkill -f 'docker-proxy.*-host-port (5432|5433)' || true; "
+                    f"  sleep 1; "
+                    f"fi; "
                     f"docker compose -f docker-compose.prod.yml up -d --remove-orphans; "
                     # Reclaim disk: prune unused images (including OLD per-SHA
                     # tags from previous deploys, not just dangling ones),


### PR DESCRIPTION
## Summary

#205 dropped \`down\` to avoid a docker-proxy port-release race. That made things worse: without \`down\`, compose's own proxy cleanup never runs, so every failed \`up\` leaves a zombie \`docker-proxy\` holding 127.0.0.1:5432. Two subsequent deploys failed identically, and the zombie pattern was verified on the VPS (a docker-proxy PID with no associated running container, still bound to 5432).

### Bigger picture from the failure logs

\`\`\`
Container career_caddy-mcp-1 Stopped
Container career_caddy-api-1 Recreate → Recreated
... (all 5 apps "Recreated")
Container career_caddy-db-1 Starting
Error: Bind for 127.0.0.1:5432 failed
\`\`\`

\`depends_on: service_healthy\` from apps → db DOES exist, but it kicks in at container-start time; the port-bind failure happens *upstream* of that. By the time db fails, apps are already Recreated (old containers gone, new ones prepared but not started), so a port-bind error tears down the whole stack with no rollback.

That's a separate compose-shape concern worth revisiting later — the \`127.0.0.1:5432\` host mapping isn't required by any container (internal traffic goes over the docker network as \`db:5432\`), and removing it would eliminate this entire class of failure. Out of scope for tonight; logging it.

## Fix

1. Restore \`docker compose down --remove-orphans\` so compose at least gets the chance to kill the proxies it owns.
2. Poll \`ss -tnl 'sport = :5432'\` for up to 30s waiting for the port to actually free. The race only fires when down+up chain in the same shell with no human-pause; the manually-typed bounce never hits it.
3. If 30s pass and the port is still bound, fall back to an explicit \`pkill -f 'docker-proxy.*-host-port (5432|5433)'\` to clear true zombies, then proceed.
4. \`up -d --remove-orphans\` runs against a clean port.

## Test plan

- [ ] Parent CI green (no build-step change).
- [ ] Deploy on this merge SHA goes green — \`docker compose down\` exits, the poll loop logs at most a few seconds of waiting, \`up -d\` succeeds.
- [ ] \`POST /api/v1/scrapes/claim-next/\` returns 200/204 on prod (not 405). 10 days of api changes finally land.
- [ ] pibu's smoke run (separate test, not gated by this PR) gets a clean preflight + claim-next cycle.