### PR TITLE
fix(compose): drop db host port bindings — unblock deploy past proxy zombies

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,9 +22,20 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
     volumes:
       - postgres_data:/var/lib/postgresql   # postgres 18+: mount the parent dir, not /data
-    ports:
-      - "127.0.0.1:5432:5432"
-      - "${TAILSCALE_IP:-127.0.0.1}:5433:5432"
+    # No host port bindings. Internal traffic (api, worker, chat, mcp)
+    # reaches postgres via the docker network as `db:5432`. Host-side
+    # psql access goes through `make shell-db` (i.e. `docker compose
+    # exec db psql`), which doesn't need a published port.
+    #
+    # Removed 2026-05-30 after a stuck docker-proxy zombie on the VPS
+    # (PIDs 3248051/3248060, root-owned) blocked 127.0.0.1:5432 and
+    # ${TAILSCALE_IP}:5433 across multiple Deploys. With no host port
+    # to bind, deploys can't fail with `Bind for ... already allocated`
+    # and the orphan proxies become harmless until the host reboots.
+    #
+    # If external (Tailscale) postgres access is needed again, re-add
+    # `${TAILSCALE_IP}:5433:5432` and run `sudo systemctl restart docker`
+    # on the VPS first to clear any lingering proxies.
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres}"]
       interval: 10s


### PR DESCRIPTION
## Summary

Deploy on #206 still failed. The pkill fallback's output revealed the real problem:

\`\`\`
pkill: killing pid 3248051 failed: Operation not permitted
pkill: killing pid 3248060 failed: Operation not permitted
\`\`\`

Both PIDs are \`docker-proxy\` processes owned by root, started hours ago, and have survived every \`compose down\` cycle (including the manual ones). They've been blocking 127.0.0.1:5432 and \${TAILSCALE_IP}:5433 the whole evening — which is why "successful bounces" left prod still serving the May 20 image. The cached old image came up on whatever ports weren't conflicted, never on what the new IMAGE_TAG asked for.

**Critically:** the zombie proxies aren't routing traffic anywhere useful. Their stale \`-container-ip 172.19.0.2\` points at a container that doesn't exist anymore — they ECONNREFUSED any connection. So the host port bindings have been *functionally* broken for hours. Removing them costs nothing currently working.

## What this changes

- \`127.0.0.1:5432:5432\` — **removed**. No container in the stack needs it; api/worker/chat/mcp all reach postgres over the docker network as \`db:5432\`. Host-side psql convenience comes from \`make shell-db\` (already \`docker compose exec db psql\`, Makefile:50), which doesn't need a published port.
- \`\${TAILSCALE_IP}:5433:5432\` — **removed**. No current consumer; was for "future remote admin" (metabase etc.). When/if needed, re-add after \`sudo systemctl restart docker\` on the VPS to clear the current zombies.

Belt-and-suspenders dagger wait/pkill from #206 stays as a safety net.

## Effect

Db comes up with no host bindings → zombies become irrelevant → apps get healthy db via internal network → the 10 days of pending api changes (claim-next/, lease sweep, queue migrations, SSE phases) finally land in prod.

## Test plan

- [ ] Parent CI green.
- [ ] Deploy on this merge SHA goes green.
- [ ] \`POST /api/v1/scrapes/claim-next/\` returns 200/204 (not 405).
- [ ] \`make shell-db\` continues to work locally.
- [ ] pibu's smoke run (separate test) completes a claim cycle.