### PR TITLE
fix(compose): renumber db host ports to 5455/5456 around proxy zombies

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,9 +22,24 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
     volumes:
       - postgres_data:/var/lib/postgresql   # postgres 18+: mount the parent dir, not /data
+    # Host ports renumbered 2026-05-30 to sidestep root-owned
+    # docker-proxy zombies that have permanently bound 5432/5433 on
+    # this VPS (PIDs 3248051, 3248060 originally; 3273989, 3273999
+    # after a daemon restart — fresh ones spawn on each cycle because
+    # `compose down` doesn't reliably reap its docker-proxy children;
+    # moby/moby#24932). Choosing fresh, never-bound host ports lets
+    # Deploy succeed without sudo on the VPS. The container port
+    # (5432) is unchanged — postgres still listens on 5432 internally,
+    # and api/worker/chat/mcp continue to reach it as `db:5432` over
+    # the docker network.
+    #
+    # External consumers updating their connection string:
+    #   - omarchy psql via tailnet: was 100.95.132.166:5433, now :5456
+    #   - any diycloud service hitting 127.0.0.1:5432 on racknerd:
+    #     update to 127.0.0.1:5455
     ports:
-      - "127.0.0.1:5432:5432"
-      - "${TAILSCALE_IP:-127.0.0.1}:5433:5432"
+      - "127.0.0.1:5455:5432"
+      - "${TAILSCALE_IP:-127.0.0.1}:5456:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres}"]
       interval: 10s


### PR DESCRIPTION
## Summary

Option C from tonight's deploy-debugging arc: leave the daemon alone, change careercaddy's db host ports so the root-owned docker-proxy zombies on 5432/5433 stop blocking us.

### Why not the other options

- **A — \`userland-proxy: false\` at the daemon level.** Would fix the proxy-zombie class forever, but affects every container on racknerd's docker daemon including diycloud (metabase et al). Wrong blast radius for a careercaddy fix.
- **B — narrow sudoers + \`sudo pkill\`.** Leaves the bug in place, just lets us clean up after each cycle. Adds a privilege and ongoing maintenance for a sidestep we don't need.
- **C — port renumber (this).** Self-contained, no daemon change, no sudo. Zombies sit on 5432/5433 forever doing nothing; we bind 5455/5456 instead.

### What changes

- \`127.0.0.1:5432:5432\` → \`127.0.0.1:5455:5432\`
- \`\${TAILSCALE_IP}:5433:5432\` → \`\${TAILSCALE_IP}:5456:5432\`

Container port stays 5432 — postgres still listens on 5432 internally, and api/worker/chat/mcp reach it as \`db:5432\` over the docker network unchanged.

### External consumers to update one time

- omarchy \`psql\` via tailnet: was \`100.95.132.166:5433\`, now \`:5456\`
- any diycloud service hitting \`127.0.0.1:5432\` on racknerd: update to \`127.0.0.1:5455\`

The dagger \`down → poll-for-port → pkill\` safety net from #206 stays — useful if zombies ever appear on the new ports too, and a no-op when they don't.

## Test plan

- [ ] Parent CI green.
- [ ] Deploy on merge SHA goes green — port bindings on 5455/5456 succeed first try (no zombies there).
- [ ] \`POST /api/v1/scrapes/claim-next/\` returns 200/204 (not 405). 10 days of pending api changes finally live.
- [ ] Tailnet psql: \`psql -h 100.95.132.166 -p 5456 -U postgres job_hunting\` from omarchy works.
- [ ] Diycloud metabase data source updated.
- [ ] pibu smoke run completes a claim cycle.