### PR TITLE
revert: tonight's deploy experiments — restore pre-tonight pipeline + ports

### DIFF
--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -528,23 +528,6 @@ class CareerCaddy:
                     f"grep -q '^IMAGE_TAG=' .env && sed -i 's/^IMAGE_TAG=.*/IMAGE_TAG={tag}/' .env || echo 'IMAGE_TAG={tag}' >> .env; "
                     f"docker compose -f docker-compose.prod.yml pull; "
                     f"docker compose -f docker-compose.prod.yml down --remove-orphans; "
-                    # docker-proxy can outlive the container that spawned it
-                    # by a few hundred ms after `down` returns; chaining `up`
-                    # immediately makes the new db container fail with
-                    # `Bind for 127.0.0.1:5432 failed: port is already
-                    # allocated`. Manual `down` then `up` typed at a shell
-                    # doesn't hit it because the human-pause is enough.
-                    # Poll until the port frees (≤30s), then fall back to
-                    # an explicit pkill if a true zombie is hanging on.
-                    f"for i in $(seq 1 30); do "
-                    f"  ss -tnl 'sport = :5432' 2>/dev/null | grep -q ':5432' || break; "
-                    f"  sleep 1; "
-                    f"done; "
-                    f"if ss -tnl 'sport = :5432' 2>/dev/null | grep -q ':5432'; then "
-                    f"  echo 'WARN: 5432 still bound after 30s, pkill docker-proxy fallback'; "
-                    f"  pkill -f 'docker-proxy.*-host-port (5432|5433)' || true; "
-                    f"  sleep 1; "
-                    f"fi; "
                     f"docker compose -f docker-compose.prod.yml up -d --remove-orphans; "
                     # Reclaim disk: prune unused images (including OLD per-SHA
                     # tags from previous deploys, not just dangling ones),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,24 +22,9 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
     volumes:
       - postgres_data:/var/lib/postgresql   # postgres 18+: mount the parent dir, not /data
-    # Host ports renumbered 2026-05-30 to sidestep root-owned
-    # docker-proxy zombies that have permanently bound 5432/5433 on
-    # this VPS (PIDs 3248051, 3248060 originally; 3273989, 3273999
-    # after a daemon restart — fresh ones spawn on each cycle because
-    # `compose down` doesn't reliably reap its docker-proxy children;
-    # moby/moby#24932). Choosing fresh, never-bound host ports lets
-    # Deploy succeed without sudo on the VPS. The container port
-    # (5432) is unchanged — postgres still listens on 5432 internally,
-    # and api/worker/chat/mcp continue to reach it as `db:5432` over
-    # the docker network.
-    #
-    # External consumers updating their connection string:
-    #   - omarchy psql via tailnet: was 100.95.132.166:5433, now :5456
-    #   - any diycloud service hitting 127.0.0.1:5432 on racknerd:
-    #     update to 127.0.0.1:5455
     ports:
-      - "127.0.0.1:5455:5432"
-      - "${TAILSCALE_IP:-127.0.0.1}:5456:5432"
+      - "127.0.0.1:5432:5432"
+      - "${TAILSCALE_IP:-127.0.0.1}:5433:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres}"]
       interval: 10s


### PR DESCRIPTION
## Summary

Roll back the layered workarounds added tonight while debugging the \`Bind for 127.0.0.1:5432\` deploy failures (PRs #205, #206, #209). Back to the dagger and compose shape that was deploying successfully through 2026-05-20.

### Why

Doug asked the sharp question — was \`pkill\` part of the procedure before this? **No.** I added it tonight in reaction to the symptom. Looking at the deploy history:

- Last green: \`df5101e\` on 2026-05-20.
- First failure: \`71cbb33\` on 2026-05-26 — a *todo-only* amendment with no code change, failing with the same port-bind error.

So the bug is in the VPS docker daemon's state (orphaned docker-proxy processes that \`compose down\` can't reap; moby/moby#24932), not in our pipeline. Adding poll loops, pkill fallbacks, and port renumbers piled procedure on top of an external issue without addressing the root cause.

## Diff

- \`dagger/src/career_caddy_pipeline.py\`: drop the down→poll→pkill loop, back to \`pull → down → up → prune\`.
- \`docker-compose.prod.yml\`: db host ports back to 5432/5433.

## Test plan (after merge)

1. Doug runs \`sudo systemctl restart docker\` on racknerd to clear every zombie proxy (including 5455/5456 ones spawned tonight).
2. A merge to main fires Deploy with the simple pre-tonight pipeline.
3. If green: procedure was always fine; the VPS just needed a clean state. We're done.
4. If red with the same symptom: the daemon has a chronic issue — evaluate either a narrow sudoers grant for \`pkill -f docker-proxy*\` (contained) or \`userland-proxy: false\` in \`/etc/docker/daemon.json\` (affects diycloud too).