### PR TITLE
fix(deploy): sudo pkill orphaned docker-proxy zombies after down

### DIFF
--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -528,6 +528,28 @@ class CareerCaddy:
                     f"grep -q '^IMAGE_TAG=' .env && sed -i 's/^IMAGE_TAG=.*/IMAGE_TAG={tag}/' .env || echo 'IMAGE_TAG={tag}' >> .env; "
                     f"docker compose -f docker-compose.prod.yml pull; "
                     f"docker compose -f docker-compose.prod.yml down --remove-orphans; "
+                    # This VPS reproduces moby/moby#24932 on every cycle —
+                    # `docker compose down` leaves orphaned root-owned
+                    # docker-proxy processes that keep listening on the
+                    # host ports our containers expose (5432, 5433, 8025,
+                    # 8030, 8031, 8087). The next `up` then fails with
+                    # `Bind for 127.0.0.1:PORT failed: port is already
+                    # allocated`. Confirmed reproducible even on a freshly
+                    # restarted docker daemon (Deploy 26708202701 on a
+                    # clean post-`systemctl restart docker` state).
+                    #
+                    # Recovery: kill any docker-proxy whose -host-port is
+                    # one of the published ports. Requires sudo because
+                    # docker-proxy is root-owned and the deploy ssh user
+                    # is unprivileged. The /etc/sudoers.d/deploy-docker-
+                    # proxy-cleanup grant scopes this to ONLY this
+                    # specific pkill invocation:
+                    #
+                    #   <deploy_user> ALL=(root) NOPASSWD: /usr/bin/pkill -f docker-proxy*
+                    #
+                    # `|| true` so a (rare) no-zombies cycle doesn't fail
+                    # the deploy when pkill exits with 1.
+                    f"sudo -n /usr/bin/pkill -f 'docker-proxy.*-host-port' || true; "
                     f"docker compose -f docker-compose.prod.yml up -d --remove-orphans; "
                     # Reclaim disk: prune unused images (including OLD per-SHA
                     # tags from previous deploys, not just dangling ones),

--- a/deploy/sudoers.d/deploy-docker-proxy-cleanup
+++ b/deploy/sudoers.d/deploy-docker-proxy-cleanup
@@ -1,0 +1,30 @@
+# Career Caddy deploy automation — narrow sudo grant.
+#
+# Lets the unprivileged ssh user used by the Dagger Deploy workflow kill
+# root-owned `docker-proxy` processes that have been orphaned from their
+# parent container. This is a workaround for moby/moby#24932: on this
+# VPS, `docker compose down` does NOT reliably reap its own docker-proxy
+# children, so the next `up` fails with
+# `Bind for 127.0.0.1:PORT failed: port is already allocated`. Without
+# this grant, the deploy ssh user can't pkill the root-owned proxies
+# and Deploy stays red forever.
+#
+# Scope: ONLY `/usr/bin/pkill -f docker-proxy*` — nothing else. The
+# pattern wildcard intentionally covers any args the deploy script may
+# pass (today it's `-f docker-proxy.*-host-port`; a more specific
+# variant might land later). pkill's `-f` matches against the full
+# command line, so the deploy user can only kill processes whose
+# cmdline begins with `docker-proxy` — which only docker itself
+# spawns.
+#
+# Install on the VPS as root:
+#
+#   sudo install -m 0440 -o root -g root \
+#     deploy/sudoers.d/deploy-docker-proxy-cleanup \
+#     /etc/sudoers.d/deploy-docker-proxy-cleanup
+#   sudo visudo -c   # verify before reloading
+#
+# Replace `deploy` below with the actual deploy ssh user if different
+# (current GitHub Actions secret: DEPLOY_SSH_USER).
+
+deploy ALL=(root) NOPASSWD: /usr/bin/pkill -f docker-proxy*


### PR DESCRIPTION
## Summary

Tonight's debugging confirmed via Deploy 26708202701 (post-bounce, clean docker daemon, reverted simple pipeline) that the VPS reproduces **moby/moby#24932 on EVERY deploy cycle**, not just after accumulated zombies. \`compose down\` does not reliably reap its own docker-proxy children, so the next \`up\` fails with \`Bind for 127.0.0.1:5432 failed: port is already allocated\`. The pipeline cannot succeed without intervention.

### Two viable contained fixes

- **\`userland-proxy: false\`** in \`/etc/docker/daemon.json\` — eliminates the class but affects every container on racknerd's daemon including diycloud's. Wrong blast radius for a careercaddy fix.
- **Narrow sudoers grant** (this PR) — contained to one specific pkill invocation. No daemon-wide changes.

## What this commits

- \`dagger/src/career_caddy_pipeline.py\`: insert \`sudo -n /usr/bin/pkill -f 'docker-proxy.*-host-port' || true\` between \`down\` and \`up\`. \`|| true\` covers the (rare) no-zombies case where pkill exits 1.
- \`deploy/sudoers.d/deploy-docker-proxy-cleanup\`: sudoers fragment to install on the VPS. Grants the deploy user ONLY this specific pkill — no broader root.

## One-time operator action required

Before this PR helps, drop the sudoers fragment on racknerd:

\`\`\`
sudo install -m 0440 -o root -g root \\
  deploy/sudoers.d/deploy-docker-proxy-cleanup \\
  /etc/sudoers.d/deploy-docker-proxy-cleanup
sudo visudo -c   # verify
\`\`\`

If the deploy ssh user isn't \`deploy\`, edit the fragment first to match \`DEPLOY_SSH_USER\`.

Until that's in place: this PR is no worse than current state (pkill silently fails with EPERM, Deploy still hits the port bind). After it's in place: every Deploy self-heals zombie proxies automatically — no manual \`systemctl restart docker\` cycles needed.

## Why I can recommend this confidently now

Earlier I tried less invasive paths first (no sudo); they all failed in instructive ways:

| PR | Approach | Result |
|---|---|---|
| #205 | Drop \`down\` entirely | Made it worse — no proxy cleanup at all |
| #206 | Restore down + poll for port + unprivileged pkill | pkill failed with EPERM (proxies root-owned) |
| #209 | Renumber db host ports to sidestep zombies | Whack-a-mole; next service (api on 8025) immediately zombied |
| #210 | Revert everything to pre-tonight pipeline | Failed identically even on clean post-bounce daemon → bug is intrinsic |
| #211 | Trigger a clean test | Confirmed the conclusion above |

Sudo grant is the smallest privilege increase that addresses the actual root cause, and it's bounded to one command pattern.

## Test plan

- [ ] Doug installs the sudoers fragment on racknerd per the recipe above.
- [ ] Merge this PR.
- [ ] Deploy runs cleanly — pkill clears any zombies between down + up.
- [ ] Subsequent deploys keep working without manual intervention.
- [ ] \`POST /api/v1/scrapes/claim-next/\` returns 200/204 (still gated separately by the unresolved token-401 issue).