### PR TITLE
feat(deploy): docker-compose.prod.yml absorbs ansible's caddy + proxy + external-volume shape

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,27 +1,43 @@
 ---
-# Production deployment — VPS via docker compose
+# Production deployment — VPS via docker compose.
 #
-# Uses pre-built images from GHCR. Core stack only (db + api + frontend).
-#
-# Deploy:
-#   docker compose -f docker-compose.prod.yml pull
-#   docker compose -f docker-compose.prod.yml up -d --remove-orphans
+# This file is cc-owned and lives at /opt/stacks/careercaddy.online/
+# on racknerd after dagger deploy scp's it. Previously ansible
+# (dc/playbooks/racknerd/careercaddy.online.yml) was also writing
+# to that path — dc unwound and archived the playbook 2026-05-31
+# so this file is the single source of truth. See cc/notes.org
+# Operations/Deploy debugging 2026-05-30 for the full story.
 #
 # Required env vars (set in .env on the server):
-#   SECRET_KEY, DB_PASSWORD, ALLOWED_HOSTS, CORS_ALLOWED_ORIGINS,
-#   CSRF_TRUSTED_ORIGINS, IMAGE_TAG, TAILSCALE_IP (optional)
+#   SECRET_KEY, DB_PASSWORD, IMAGE_TAG, EMAIL_HOST, EMAIL_HOST_USER,
+#   EMAIL_HOST_PASSWORD. Optional: ALLOWED_HOSTS, CORS_ALLOWED_ORIGINS,
+#   CSRF_TRUSTED_ORIGINS, TAILSCALE_IP, FRONTEND_URL, LOGFIRE_TOKEN.
+#
+# Deploy:
+#   docker compose pull
+#   docker compose down --remove-orphans
+#   docker compose up -d --remove-orphans
+
+# Pin the compose project name so it doesn't shift if the dir is
+# renamed. Container names are also explicit per-service so `down`
+# always finds the correct rows even if the project label drifts.
+name: careercaddyonline
 
 services:
 
   db:
     image: postgres:18
+    container_name: careercaddy-db
     restart: unless-stopped
+    networks:
+      - default
     environment:
       POSTGRES_DB: ${DB_NAME:-job_hunting}
       POSTGRES_USER: ${DB_USER:-postgres}
       POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
     volumes:
-      - postgres_data:/var/lib/postgresql   # postgres 18+: mount the parent dir, not /data
+      # postgres 18+: mount the parent dir, not /data
+      - postgres_data:/var/lib/postgresql
     ports:
       - "127.0.0.1:5432:5432"
       - "${TAILSCALE_IP:-127.0.0.1}:5433:5432"
@@ -34,14 +50,18 @@ services:
 
   api:
     image: ghcr.io/overcast-software/career_caddy_api:${IMAGE_TAG:-latest}
+    container_name: careercaddy-api
     restart: unless-stopped
+    networks:
+      - default
+      - proxy
     ports:
       - "127.0.0.1:8025:8000"
     environment:
       DEBUG: "False"
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
       DATABASE_URL: postgresql://${DB_USER:-postgres}:${DB_PASSWORD}@db:5432/${DB_NAME:-job_hunting}
-      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-api.careercaddy.online,localhost,127.0.0.1,api}
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-careercaddy.online,api.careercaddy.online,localhost,127.0.0.1,api}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-https://careercaddy.online}
       CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS:-https://careercaddy.online}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
@@ -76,6 +96,13 @@ services:
       start_period: 30s
       retries: 3
     mem_limit: 512m
+    labels:
+      caddy: api.careercaddy.online
+      caddy.import: cc_log
+      caddy.reverse_proxy: "{{upstreams 8000}}"
+      caddy.reverse_proxy.transport: http
+      caddy.reverse_proxy.transport.read_timeout: 2m
+      caddy.reverse_proxy.transport.write_timeout: 2m
 
   # ── Worker ──────────────────────────────────────────────────────────────
   # django-q2 task worker — Phase 1 of Plans/Job-queue integration. Shares
@@ -87,14 +114,17 @@ services:
   # atomic-deleted in Phase 4).
   worker:
     image: ghcr.io/overcast-software/career_caddy_api:${IMAGE_TAG:-latest}
+    container_name: careercaddy-worker
     restart: unless-stopped
+    networks:
+      - default
     entrypoint: ""
     command: python manage.py qcluster
     environment:
       DEBUG: "False"
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
       DATABASE_URL: postgresql://${DB_USER:-postgres}:${DB_PASSWORD}@db:5432/${DB_NAME:-job_hunting}
-      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-api.careercaddy.online,localhost,127.0.0.1,worker}
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-careercaddy.online,api.careercaddy.online,localhost,127.0.0.1,worker}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       SCRAPING_ENABLED: ${SCRAPING_ENABLED:-False}
       SA_SCHEMA_ON_POST_MIGRATE: "False"  # api runs migrations; worker just consumes
@@ -125,12 +155,27 @@ services:
 
   frontend:
     image: ghcr.io/overcast-software/career-caddy-frontend:${IMAGE_TAG:-latest}
+    container_name: careercaddy-frontend
     restart: unless-stopped
+    networks:
+      - default
+      - proxy
     ports:
       - "127.0.0.1:8087:80"
     depends_on:
       - api
     mem_limit: 64m
+    labels:
+      caddy: careercaddy.online
+      caddy.import: cc_log
+      caddy.encode: zstd gzip
+      # Same-origin: SPA emits /api/v1/... to its own host; we route
+      # those to the api container, preserving the /api prefix (handle,
+      # not handle_path) so Django routes them correctly. The catch-all
+      # reverse_proxy below handles everything else.
+      caddy.handle: /api/*
+      caddy.handle.reverse_proxy: api:8000
+      caddy.reverse_proxy: "{{upstreams 80}}"
 
   # ── Public MCP Server ────────────────────────────────────────────────────
   # Exposes career-data tools via MCP protocol at mcp.careercaddy.online.
@@ -139,7 +184,11 @@ services:
 
   mcp:
     image: ghcr.io/overcast-software/career_caddy_ai:${IMAGE_TAG:-latest}
+    container_name: careercaddy-mcp
     restart: unless-stopped
+    networks:
+      - default
+      - proxy
     ports:
       - "127.0.0.1:8030:8000"
     environment:
@@ -152,21 +201,35 @@ services:
       api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8000/mcp || exit 1"]
+      # /mcp requires auth (jh_* API key), so a bare GET returns 401 —
+      # which IS the server-is-up signal. Accept any 2xx or 4xx as
+      # healthy; 5xx or connection failure marks unhealthy. Without
+      # this, caddy-docker-proxy filters the container out of routing
+      # and external clients see 502 instead of the proper 401.
+      test: ["CMD-SHELL", "curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8000/mcp | grep -qE '^[24]'"]
       interval: 30s
       timeout: 5s
       start_period: 15s
       retries: 3
     mem_limit: 256m
+    labels:
+      caddy: mcp.careercaddy.online
+      caddy.import: cc_log
+      caddy.reverse_proxy: "{{upstreams 8000}}"
 
   # ── Chat Server (internal) ─────────────────────────────────────────────
-  # SSE streaming chat endpoint — API proxies to this service.
+  # SSE streaming chat endpoint — api proxies to this service.
   # Not exposed to the internet; only reachable via the Docker network.
+  # No caddy label — internal-only.
 
   chat:
     image: ghcr.io/overcast-software/career_caddy_ai:${IMAGE_TAG:-latest}
+    container_name: careercaddy-chat
     restart: unless-stopped
+    networks:
+      - default
     ports:
+      # Kept for local debug only. Could be dropped post-migration.
       - "127.0.0.1:8031:8000"
     environment:
       CC_API_BASE_URL: "http://api:8000"
@@ -188,6 +251,24 @@ services:
       retries: 3
     mem_limit: 512m
 
+networks:
+  default:
+  proxy:
+    # Created and managed by dc's tasks/debian/caddy.yml on racknerd.
+    # caddy-docker-proxy watches containers on this network for `caddy:`
+    # labels and synthesizes site blocks on the fly. Marking it
+    # `external: true` here means compose does NOT create/destroy it.
+    external: true
+
+# External volumes — created under the legacy `career_caddy_` project
+# prefix when this stack first ran from ~/Projects/career_caddy. Kept
+# the names so the migration to /opt/stacks/careercaddy.online +
+# project=careercaddyonline does not orphan the postgres data or
+# screenshots volume. Compose will NOT create/destroy these here.
 volumes:
   postgres_data:
+    external: true
+    name: career_caddy_postgres_data
   screenshots:
+    external: true
+    name: career_caddy_screenshots

--- a/todo.org
+++ b/todo.org
@@ -95,10 +95,47 @@ Some changes touch multiple repos (e.g. API contract change ripples into fronten
 - New UI components must use Tailwind utilities following HyperUI patterns. Never custom CSS.
 - Use hyperui, tailwind, and defined color palettes when writing UI html.
 - Submodule scope on entry headings goes in proper org tags (=:frontend:=, =:api:=, =:ai:=, =:bug:=), NOT bracket-suffix annotations like =[frontend]=. Tags stack: =:frontend:bug:=. Don't bulk-rewrite historical =[frontend]= entries.
+** TODO [dc] careercaddy.online ansible ownership unwound — proceed with Deploy PR :dc:
+
+dc has unwound ansible ownership of careercaddy.online on racknerd
+per cc's Inbox/Bug ask. Concretely:
+
+1. =playbooks/racknerd/careercaddy.online.yml= is ARCHIVED with a
+   fail-fast guard (=tags: always= so neither =--tags= nor =--skip-tags=
+   bypass it). The file is kept as archaeology — original tasks remain
+   below the guard but ansible will never reach them.
+
+2. =/opt/stacks/careercaddy.online/docker-compose.yml= will not be
+   re-templated by dc. cc's Deploy scp owns that file unambiguously.
+
+3. Subdomains still dc-owned (no change): metabase.careercaddy.online,
+   careercaddy.dev, analytics.careercaddy.online. The
+   =*.careercaddy.online= wildcard catch-all in
+   =tasks/debian/caddy-racknerd.yml= stays — it picks up any subdomain
+   NOT matched by a more-specific block, which is exactly the dc
+   surface.
+
+4. Question answered: =proxy= external docker network on racknerd is
+   DC-CREATED via =tasks/debian/caddy.yml= as part of the caddy stack
+   deploy. cc's compose should reference it as:
+     networks:
+       proxy:
+         external: true
+   and add caddy labels (=caddy: careercaddy.online, ...= +
+   =caddy.reverse_proxy: "{{upstreams 8000}}"= etc.) —
+   caddy-docker-proxy on racknerd will pick them up and add specific
+   site blocks that take precedence over the dc-owned wildcard catch-all.
+
+cc can ship the Deploy PR (caddy labels + proxy network reference)
+without dc needing to touch racknerd further. ping dc if anything on
+the caddy edge misbehaves.
+
+dc-side record: =~/Network/syncthing/Projects/diycloud/notes.org= ::
+=Operations/Unwound careercaddy.online ansible ownership= (2026-05-31).
 ** DONE [cc_auto] Phase 1 complete — ready for =git submodule add automation/= [2026-05-30] :cc_auto:shared-contract:
 CLOSED: [2026-05-30 Sat]
 :PROPERTIES:
-:LAST_TOUCHED: [2026-05-30]
+:LAST_TOUCHED: [2026-05-31]
 :HANDOFF_TO: cc-orchestrator
 :SIGNAL_LOCATION: career_caddy_automation/notes.org "Phase 1 complete — ready for parent submodule-add [2026-05-30]"
 :REMOTE: git@github.com:overcast-software/career_caddy_automation.git


### PR DESCRIPTION
## Summary

Closes the final piece of tonight's deploy-debugging arc. Per dc's reply (in cc/todo.org Inbox), ansible no longer owns \`/opt/stacks/careercaddy.online/docker-compose.yml\` on racknerd. cc's dagger deploy scp now owns it unambiguously. For caddy-docker-proxy routing + the existing postgres data to keep working after ansible stops contributing them, the repo's compose has to carry the labels + proxy network + external volume references itself. That's this PR.

## Why the deploy was failing all night

Two compose projects in the same directory on the VPS:

- ansible's \`docker-compose.yml\` → project \`careercaddyonline\`, container names \`careercaddy-*\`, on \`default + proxy\`, with caddy labels.
- cc's \`docker-compose.prod.yml\` (scp'd by dagger) → project \`career_caddy\`, autogen names, default bridge only, no labels.

Every Deploy ran \`docker compose -f docker-compose.prod.yml down/up\` against project \`career_caddy\`, which had no live containers. \`down\` was a no-op; \`up\` tried to bind 5432/8025/etc. already held by the live ansible-managed containers. Five hours of debugging tonight (PRs #205/#206/#207/#209/#210/#211/#212 all closed/reverted) chased the wrong cause.

Full investigation arc:
- cc/notes.org \`Operations/Deploy debugging 2026-05-30\`
- dc/notes.org \`Operations/Unwound careercaddy.online ansible ownership\`

## Changes to docker-compose.prod.yml

- \`name: careercaddyonline\` at the top — pin project name; down/up never drift.
- \`container_name:\` on every service (\`careercaddy-{db,api,frontend,mcp,chat,worker}\`) — stable handles.
- \`api\` / \`frontend\` / \`mcp\` join \`default + proxy\` (public-facing).
- \`chat\` / \`db\` / \`worker\` stay on \`default\` only (internal-only).
- caddy labels mirroring what ansible was contributing:
  - api → \`api.careercaddy.online\` + transport read/write timeout 2m
  - frontend → \`careercaddy.online\` + \`/api/*\` handle routing to \`api:8000\` (same-origin SPA)
  - mcp → \`mcp.careercaddy.online\`
  - all three import \`cc_log\`.
- \`networks.proxy: external: true\` — owned by dc's caddy stack, compose doesn't manage it.
- \`volumes.postgres_data\` / \`screenshots\` as external pointing at the legacy \`career_caddy_*\` volume names so the migration to \`project=careercaddyonline\` doesn't orphan the data.
- \`ALLOWED_HOSTS\` default widened to include \`careercaddy.online\`.
- mcp healthcheck uses the auth-aware \`401-is-healthy\` pattern (curl|grep -E '^[24]') instead of \`curl -f\` (which would mark the container unhealthy on the legitimate 401 from \`/mcp\` and pull it out of caddy routing).

## Test plan

- [ ] Parent CI green.
- [ ] Deploy on this merge SHA goes green — \`down\` finds and stops the live containers (project matches now); \`up\` recreates them on \`default + proxy\` with the labels.
- [ ] caddy-docker-proxy picks up the labels and routes:
  - \`https://careercaddy.online\` → frontend
  - \`https://api.careercaddy.online\` → api
  - \`https://mcp.careercaddy.online\` → mcp
- [ ] postgres data survives the down/up (external volume; same name).
- [ ] Token-401 still needs separate investigation in TablePlus (unaffected by this PR).