### PR TITLE
feat(ci): arm64 dev-tag publish workflow + dagger platform arg

### DIFF
--- a/.github/workflows/publish-arm64-dev.yml
+++ b/.github/workflows/publish-arm64-dev.yml
@@ -1,0 +1,75 @@
+name: Publish arm64 dev images
+
+# Cross-builds arm64 images for the `dev` branch and publishes to GHCR
+# as `:dev-<sha>` (immutable) and `:dev` (moving). No SSH deploy step —
+# fetch is operator-driven (run `docker compose pull` wherever you want
+# the arm64 images, e.g. a Raspberry Pi).
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  ci:
+    name: Build and test (API + Frontend)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install Dagger CLI
+        run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.8 BIN_DIR=/usr/local/bin sh
+
+      - name: Build and test API
+        run: dagger -m ./dagger call build-api
+
+      - name: Build and test Frontend
+        run: dagger -m ./dagger call build-frontend
+
+      - name: Test AI (toolsets + security)
+        run: dagger -m ./dagger call test-ai
+
+  publish-arm64:
+    name: Publish arm64 images to GHCR (:dev, :dev-<sha>)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: ci
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up QEMU (arm64 emulation for cross-build)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Install Dagger CLI
+        run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.8 BIN_DIR=/usr/local/bin sh
+
+      - name: Publish arm64 images — immutable :dev-<sha>
+        run: |
+          dagger -m ./dagger call publish \
+            --registry-token=env:GHCR_TOKEN \
+            --org=overcast-software \
+            --tag=dev-${{ github.sha }} \
+            --platform=linux/arm64 \
+            --registry-username=${{ github.actor }}
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+
+      - name: Publish arm64 images — moving :dev tag
+        run: |
+          dagger -m ./dagger call publish \
+            --registry-token=env:GHCR_TOKEN \
+            --org=overcast-software \
+            --tag=dev \
+            --platform=linux/arm64 \
+            --registry-username=${{ github.actor }}
+        env:
+          GHCR_TOKEN: ${{ github.token }}

--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -433,6 +433,7 @@ class CareerCaddy:
         org: str = "overcast-software",
         tag: str = "latest",
         registry_username: str = "",
+        platform: str = "",
         frontend_api_host: str = "",
     ) -> list[str]:
         """Build all images and push to GHCR. Returns list of pushed image refs.
@@ -442,6 +443,8 @@ class CareerCaddy:
             org: GitHub organization (used in image path)
             tag: Image tag (use git SHA for immutable tags)
             registry_username: GitHub actor username for GHCR auth (defaults to org)
+            platform: Target platform (e.g. "linux/arm64"); empty = engine
+                native (amd64 in CI). Use with QEMU for cross-builds.
             frontend_api_host: API origin baked into the frontend production
                 build. Default is empty → same-origin (SPA emits /api/v1/...;
                 outer proxy routes /api/* to the api container). Pass a full
@@ -452,16 +455,23 @@ class CareerCaddy:
         frontend_ref = f"{REGISTRY}/{org}/{FRONTEND_IMAGE}:{tag}"
         ai_ref = f"{REGISTRY}/{org}/{AI_IMAGE}:{tag}"
 
+        build_kwargs: dict = {}
+        if platform:
+            build_kwargs["platform"] = dagger.Platform(platform)
+
         pushed_api = await (
             api_src
-            .docker_build()
+            .docker_build(**build_kwargs)
             .with_registry_auth(REGISTRY, username, registry_token)
             .publish(api_ref)
         )
 
         pushed_frontend = await (
             frontend_src
-            .docker_build(build_args=[dagger.BuildArg("API_HOST", frontend_api_host)])
+            .docker_build(
+                build_args=[dagger.BuildArg("API_HOST", frontend_api_host)],
+                **build_kwargs,
+            )
             .with_registry_auth(REGISTRY, username, registry_token)
             .publish(frontend_ref)
         )
@@ -469,7 +479,10 @@ class CareerCaddy:
         # AI image: build without Camoufox (browser runs on Pi, not VPS)
         pushed_ai = await (
             ai_src
-            .docker_build(build_args=[dagger.BuildArg("INSTALL_CAMOUFOX", "false")])
+            .docker_build(
+                build_args=[dagger.BuildArg("INSTALL_CAMOUFOX", "false")],
+                **build_kwargs,
+            )
             .with_registry_auth(REGISTRY, username, registry_token)
             .publish(ai_ref)
         )


### PR DESCRIPTION
## Summary

Adds a generic OSS-friendly arm64 publish path for the `dev` branch. No operator-specific topology — no LAN IPs, no SSH targets, no personal host naming.

- `.github/workflows/publish-arm64-dev.yml` — on push to `dev`, run CI + cross-build arm64 images via QEMU and publish to GHCR as `:dev` (moving) and `:dev-<sha>` (immutable). No SSH deploy step. Operators pull from wherever they want the images (e.g. a Raspberry Pi on their LAN).
- `dagger/src/career_caddy_pipeline.py` — `publish()` gains `--platform` arg for cross-build, threaded through all three `docker_build()` calls.

## What was deliberately NOT included

Operator-private deploy mechanics live in operator dotfiles, not this repo:
- SSH-pull Makefile targets (`pull-pibu` etc.) — these embed operator LAN topology
- CLAUDE.md "dev environment" section — references operator's private DNS / playbook repos
- Hardcoded LAN host IPs

The workflow + dagger arg are the **generic primitives**; any operator can wire their own pull-side mechanics around them.

## Test plan

- [x] `make ci` green locally (api 1037 / frontend 357 / automation 37, all lint clean)
- [ ] Merge → no Deploy fires (publish-arm64-dev triggers on `dev` branch only, not `main`)
- [ ] Subsequent push to `dev` exercises the workflow