### PR TITLE
chore(compose): pass INSTANCE_ORIGIN through to api container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,12 @@ ALLOWED_HOSTS=localhost,127.0.0.1
 CORS_ALLOWED_ORIGINS=http://localhost:4200
 CSRF_TRUSTED_ORIGINS=http://localhost:4200
 
+# ── ActivityPub federation ────────────────────────────────────────────────
+# The public origin where actor URIs and WebFinger are served. Leave unset
+# for local dev (defaults to http://localhost:8000). Set to https://yourdomain.tld
+# in prod so actor URIs render correctly (e.g. https://careercaddy.online/actors/<user>).
+# INSTANCE_ORIGIN=
+
 # ── JWT (optional overrides) ──────────────────────────────────────────────
 JWT_ACCESS_TOKEN_LIFETIME_MINUTES=15
 JWT_REFRESH_TOKEN_LIFETIME_DAYS=7

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -84,6 +84,7 @@ services:
       FRONTEND_URL: ${FRONTEND_URL:-https://careercaddy.online}
       SCREENSHOT_DIR: /app/screenshots
       LOGFIRE_TOKEN: ${LOGFIRE_TOKEN:-}
+      INSTANCE_ORIGIN: ${INSTANCE_ORIGIN:-http://localhost:8000}
     volumes:
       - screenshots:/app/screenshots
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       EMAIL_USE_TLS: ${EMAIL_USE_TLS:-True}
       DEFAULT_FROM_EMAIL: ${DEFAULT_FROM_EMAIL:-noreply@localhost}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:4200}
+      INSTANCE_ORIGIN: ${INSTANCE_ORIGIN:-http://localhost:8000}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- `docker-compose.prod.yml` — api service now lists `INSTANCE_ORIGIN: ${INSTANCE_ORIGIN:-http://localhost:8000}` in `environment:` so the operator-set value in `/opt/stacks/careercaddy.online/.env` reaches the container.
- `docker-compose.yml` — same wiring for the dev compose, keeping local-dev parity.
- `.env.example` — new commented-out `# INSTANCE_ORIGIN=` line under a fresh ActivityPub federation section, with the default-fallback rationale.

## Why

ActivityPub Phase 5a (PRs #214/#215) shipped `_instance_origin()` in `api/job_hunting/lib/as_object.py`, which prefers `INSTANCE_ORIGIN`, falls back to `CAREER_CADDY_INSTANCE`, then to `http://localhost:8000`. On racknerd today the operator's `.env` sets `INSTANCE_ORIGIN=https://careercaddy.online`, but Docker never injected it into the api container because the compose file didn't reference it — actor URIs in prod still resolve as `http://localhost:8000/actors/<user>`. This wires the passthrough so post-deploy the value lands where the code reads it.

## Test plan

- [x] `docker compose -f docker-compose.prod.yml --env-file /dev/null config` shows `INSTANCE_ORIGIN: http://localhost:8000` (documented fallback)
- [x] `docker compose -f docker-compose.yml config` shows `INSTANCE_ORIGIN: <value from .env>` for api service
- [x] `make ci` green locally — api 1037 / frontend 357 / automation 37 pass
- [ ] After Deploy lands: operator runs `docker compose -f /opt/stacks/careercaddy.online/docker-compose.prod.yml exec api env | grep INSTANCE_ORIGIN` → expects `https://careercaddy.online`
- [ ] After Deploy lands: `curl https://api.careercaddy.online/actors/dough -H 'Accept: application/activity+json' | jq .id` → expects `https://careercaddy.online/actors/dough`