### PR TITLE
chore(deploy): align dagger app_dir default with /opt/stacks/careercaddy.online

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ dagger -m ./dagger call lint-automation    # ruff-check automation (cc_auto)
 dagger -m ./dagger call test-automation    # pytest in automation (cc_auto)
 dagger -m ./dagger call build-ai           # build AI image with camoufox
 dagger -m ./dagger call publish --registry-token=env:GITHUB_TOKEN --org=overcast-software --tag=latest
-dagger -m ./dagger call deploy --ssh-key=file:~/.ssh/id_ed25519 --host=<vps> --app-dir=/opt/career-caddy --tag=latest
+dagger -m ./dagger call deploy --ssh-key=file:~/.ssh/id_ed25519 --host=<vps> --app-dir=/opt/stacks/careercaddy.online --tag=latest
 ```
 
 ## Gitflow

--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -9,7 +9,7 @@ Usage (from repo root):
   dagger -m ./dagger call build-frontend
   dagger -m ./dagger call build-ai
   dagger -m ./dagger call publish --registry-token=env:GITHUB_TOKEN --org=overcast-software --tag=latest
-  dagger -m ./dagger call deploy --ssh-key=file:~/.ssh/id_ed25519 --host=your-vps-ip --app-dir=/home/oldbones/Projects/career_caddy --tag=latest
+  dagger -m ./dagger call deploy --ssh-key=file:~/.ssh/id_ed25519 --host=your-vps-ip --app-dir=/opt/stacks/careercaddy.online --tag=latest
 
 In GitHub Actions, call via: dagger -m ./dagger call publish ...
 
@@ -495,7 +495,7 @@ class CareerCaddy:
         ssh_key: Secret,
         host: str,
         compose_file: Annotated[dagger.File, DefaultPath("../docker-compose.prod.yml")],
-        app_dir: str = "/home/oldbones/Projects/career_caddy",
+        app_dir: str = "/opt/stacks/careercaddy.online",
         tag: str = "latest",
         ssh_user: str = "deploy",
     ) -> str:


### PR DESCRIPTION
## Summary

Cosmetic alignment after tonight's prod stack cutover from `/home/oldbones/Projects/career_caddy` → `/opt/stacks/careercaddy.online` on racknerd.

- `dagger/src/career_caddy_pipeline.py` — `publish()` docstring example + `deploy()` function default for `app_dir`
- `CLAUDE.md` — CI/CD example deploy command

All three sites now show `/opt/stacks/careercaddy.online`, matching the convention used by peer stacks on the same VPS (caddy, analytics, dougheadleycom, etc.).

## No CI/Deploy behavior change

The GH Actions Deploy workflow reads from the `DEPLOY_APP_DIR` secret, which was updated server-side as part of the cutover. This PR just removes the stale path from the documented examples + the default a hand-invocation of `dagger call deploy` would inherit.

## Test plan

- [x] `make ci` green locally (api 1037 / frontend 357 / automation 37, all lint clean)
- [ ] Merge → Deploy fires → confirms the secret-driven path still works end-to-end