### PR TITLE
chore: route ActivityPub federation paths to api on apex host

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -172,10 +172,19 @@ services:
       caddy.encode: zstd gzip
       # Same-origin: SPA emits /api/v1/... to its own host; we route
       # those to the api container, preserving the /api prefix (handle,
-      # not handle_path) so Django routes them correctly. The catch-all
-      # reverse_proxy below handles everything else.
-      caddy.handle: /api/*
-      caddy.handle.reverse_proxy: api:8000
+      # not handle_path) so Django routes them correctly.
+      caddy.handle_0: /api/*
+      caddy.handle_0.reverse_proxy: api:8000
+      # ActivityPub federation: WebFinger + Actor URIs MUST live on the
+      # apex host because federation peers resolve via the host in the
+      # acct: URI. The api routes these at root paths — not /api/* —
+      # per RFC 7033 and ActivityPub conventions; see
+      # api/job_hunting/urls.py lines 135-152.
+      caddy.@federation.path_0: /.well-known/webfinger
+      caddy.@federation.path_1: /actors/*
+      caddy.handle_1: "@federation"
+      caddy.handle_1.reverse_proxy: api:8000
+      # Catch-all: SPA fallback for everything else.
       caddy.reverse_proxy: "{{upstreams 80}}"
 
   # ── Public MCP Server ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

WebFinger + Actor URIs were unreachable from federated peers. The api code shipped via Phase 5a-5e (PRs api#141..#146, in prod since 2026-06-02), but Caddy on `careercaddy.online` only routed `/api/*` to the api container — every other path (including `/.well-known/webfinger` and `/actors/*`) fell to the frontend SPA, which returns `index.html` as HTML 200. Mastodon parsed that as a failed lookup.

Surfaced when `@dough@careercaddy.online` didn't appear in Mastodon search even though `https://api.careercaddy.online/.well-known/webfinger?resource=acct:dough@careercaddy.online` returns valid `application/jrd+json`.

## What changed

`docker-compose.prod.yml` frontend service labels:

- Reindexed existing `caddy.handle: /api/*` → `caddy.handle_0`
- Added `@federation` named matcher with paths `/.well-known/webfinger` and `/actors/*`
- Added `caddy.handle_1` routing `@federation` → `api:8000`
- SPA catch-all (`caddy.reverse_proxy`) unchanged

Pattern lifted from `diycloud/todo.org` — Doug had already sketched the exact label shape there.

## Test plan

- [x] Verified api code responds correctly via `api.careercaddy.online` (returns JRD JSON)
- [ ] After Deploy: `curl 'https://careercaddy.online/.well-known/webfinger?resource=acct:dough@careercaddy.online'` returns JRD JSON (not HTML)
- [ ] After Deploy: Mastodon search for `@dough@careercaddy.online` resolves the actor