### PR TITLE
feat: scrape graph trace fix + CI output cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,48 +107,14 @@ ci-lint-frontend:
 ci-lint-automation:
 	dagger -m ./dagger call lint-automation
 
-# Concise reports: surface failure blocks + summary; suppress dagger noise.
-# Pass FULL=1 to dump the entire test log unfiltered.
 ci-test-api:
-	@set -o pipefail; \
-	if [ -n "$(FULL)" ]; then \
-		dagger -m ./dagger call test-api stdout 2>&1; \
-	else \
-		dagger -m ./dagger call test-api stdout 2>&1 | awk ' \
-			/^(FAIL|ERROR): / { hit=1; n=25 } \
-			/^={70}/ { hit=1; n=25 } \
-			/^Ran [0-9]+ tests/ { print } \
-			/^(OK|FAILED)( |$$)/ { print } \
-			hit { print; if (n-- <= 0) hit=0 } \
-		'; \
-	fi
+	dagger -m ./dagger call test-api
 
 ci-test-frontend:
-	@set -o pipefail; \
-	if [ -n "$(FULL)" ]; then \
-		dagger -m ./dagger call test-frontend stdout 2>&1; \
-	else \
-		dagger -m ./dagger call test-frontend stdout 2>&1 | awk ' \
-			/^not ok / { hit=1; n=20; print; next } \
-			/^# (tests|pass|fail|skip|todo) / { print } \
-			hit { print; if (n-- <= 0) hit=0 } \
-		'; \
-	fi
+	dagger -m ./dagger call test-frontend
 
 ci-test-automation:
-	@set -o pipefail; \
-	if [ -n "$(FULL)" ]; then \
-		dagger -m ./dagger call test-automation stdout 2>&1; \
-	else \
-		dagger -m ./dagger call test-automation stdout 2>&1 | awk ' \
-			/^FAILED / { hit=1; n=15; print; next } \
-			/^ERROR / { hit=1; n=15; print; next } \
-			/====+ FAILURES ====+/ { hit=1; n=40; print; next } \
-			/====+ ERRORS ====+/ { hit=1; n=40; print; next } \
-			/[0-9]+ (passed|failed|error|skipped|deselected|warning)/ { print } \
-			hit { print; if (n-- <= 0) hit=0 } \
-		'; \
-	fi
+	dagger -m ./dagger call test-automation
 
 ci-lint: ci-lint-api ci-lint-frontend ci-lint-automation
 ci-test: ci-test-api ci-test-frontend ci-test-automation

--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -198,7 +198,7 @@ class CareerCaddy:
             .with_exec([
                 "bash", "-c",
                 "set -o pipefail; "
-                "uv run python manage.py test -v 2 --keepdb --noinput 2>&1 "
+                "uv run python manage.py test -v 1 --keepdb --noinput 2>&1 "
                 "| tee /test.log",
             ])
             # Belt-and-suspenders: even if the runner ever exits 0 with
@@ -320,7 +320,7 @@ class CareerCaddy:
             .with_exec([
                 "bash", "-c",
                 "set -o pipefail; "
-                "uv run python manage.py test -v 2 --keepdb --noinput 2>&1 "
+                "uv run python manage.py test -v 1 --keepdb --noinput 2>&1 "
                 "| tee /test.log",
             ])
             .with_exec([


### PR DESCRIPTION
## Summary
Three concerns bundled per Doug 2026-06-09 (option b on the awk roll-back conversation):

1. **frontend pin → 72d38c4** — [career_caddy_frontend#181](https://github.com/overcast-software/career_caddy_frontend/pull/181) fixes the missing visited-path on =/scrapes/:id/graph=. Root cause: Ember Data 5+ =AdapterPopulatedRecordArray= no longer exposes =.toArray()=, so =routes/scrapes/graph.js= silently returned an empty trace. Same fix applied to =scrapes/item= screenshot list and =cover-letters= polling. Regression test added.
2. **Makefile** — strip the awk suppression from =ci-test-{api,frontend,automation}=. Default to raw dagger stdout. Restores progress visibility during long runs (sub-agents were appearing hung because awk produced no output until completion). Original wrapper was added in =fbb2e6b= (2026-05-08, agent commit "concise dagger test reports via make") — well-intentioned but the trade-off was wrong: visibility flood beats apparent-hang.
3. **dagger pipeline** — Django test verbosity =-v 2= → =-v 1= in both =test_api= and =build_api=. Cuts the natural output flood that made awk-suppression tempting. Still emits the =Ran N tests in T= + =OK / FAILED= summary lines; drops the per-test name dump.

## Test plan
- [x] frontend PR #181 merged green (368 frontend tests pass).
- [x] Local =make ci= run pre-this-commit (Phase A api work) was already exit 0 — no functional change to the test runs themselves.
- [ ] Post-merge Deploy fires; subsequent =make ci= runs stream raw output.