### PR TITLE
chore(make): include worker in `make up` core stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,9 @@ export
 
 # ── Dev stack ──────────────────────────────────────────────────────────────
 
-up: ## Start core dev stack (db + api + frontend + chat)
+up: ## Start core dev stack (db + api + frontend + chat + worker)
 	docker compose down --remove-orphans 2>/dev/null || true
-	docker compose up db api frontend chat
+	docker compose up db api frontend chat worker
 
 up-full: ## Start all services including browser-mcp
 	docker compose down --remove-orphans 2>/dev/null || true


### PR DESCRIPTION
Doug 2026-06-09: ScrapeProfile sharpen endpoint shipped today enqueues an async_task; nothing consumed the queue because =make up= didn't bring up the qcluster worker. Adding =worker= to the default core stack so async jobs process by default.