### PR TITLE
chore(prod): drop rn worker count to 1 via Q_WORKERS env

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -129,6 +129,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       SCRAPING_ENABLED: ${SCRAPING_ENABLED:-False}
       SA_SCHEMA_ON_POST_MIGRATE: "False"  # api runs migrations; worker just consumes
+      Q_WORKERS: "1"  # rn drops to 1; off-rn worker stacks set their own
       USE_MCP_BROWSER_AGENT: "False"
       CHAT_SERVICE_URL: "http://chat:8000"
       EMAIL_BACKEND: ${EMAIL_BACKEND:-django.core.mail.backends.smtp.EmailBackend}


### PR DESCRIPTION
Picks up [career_caddy_api#161](https://github.com/overcast-software/career_caddy_api/pull/161) — env-driven =Q_CLUSTER['workers']= — and sets =Q_WORKERS=1= on rn's =worker= container in =docker-compose.prod.yml=.

Frees ~95 MiB on racknerd. Off-rn worker stacks (pibu compose, etc.) default to 2 since they don't set =Q_WORKERS=. Apply per-host as needed.