### PR TITLE
chore(prod): bump api + chat mem_limit 512m -> 768m

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -96,7 +96,7 @@ services:
       timeout: 5s
       start_period: 30s
       retries: 3
-    mem_limit: 512m
+    mem_limit: 768m
     labels:
       caddy: api.careercaddy.online
       caddy.import: cc_log
@@ -260,7 +260,7 @@ services:
       timeout: 5s
       start_period: 15s
       retries: 3
-    mem_limit: 512m
+    mem_limit: 768m
 
 networks:
   default:


### PR DESCRIPTION
## Summary

- Belt-and-suspenders for the cc-api SSE-handler fix (pin-bump merged in #255). Even with the handler fix, the existing 512 MiB ceiling sits ~40% above today's steady-state api RSS (~318 MiB) — too thin a margin for SSE streams that hold resident memory.
- Bump `api` and `chat` `mem_limit: 512m -> 768m` (~50% headroom over observed steady-state). Both serve SSE; the same failure mode applies.
- Other services audited and left alone:
  - `db` 512m (independent postgres footprint)
  - `worker` 384m (Q_WORKERS=1 from #254 already reduced footprint)
  - `mcp` 256m (below the 512m bump threshold)
  - `frontend` 64m (static nginx)

## Why these numbers

- Observed api steady-state: ~318 MiB resident.
- 768 MiB = ~2.4x steady-state, ~50% safety margin over post-fix expected load.
- racknerd is small; we deliberately stop at 768 to leave room for db + worker + mcp + chat + frontend on the same daemon. If post-deploy stats show we're still cresting under SSE load, the next move is a separate audit, not reflexive further bumps.

## Test plan

- [x] `make ci` passed locally (lint + test api + frontend + automation all green).
- [ ] After merge + Deploy lands, ssh racknerd: `docker stats --no-stream careercaddy-api` should read `... / 768MiB` in the MEM USAGE / LIMIT column.
- [ ] Same check for `careercaddy-chat`.
- [ ] No new OOM SIGKILLs in `docker logs careercaddy-api` after running an SSE stream end-to-end.