### PR TITLE
chore: add e2e/ submodule + pre-push canary against cc.dev

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "automation"]
 	path = automation
 	url = git@github.com:overcast-software/career_caddy_automation.git
+[submodule "e2e"]
+	path = e2e
+	url = git@github.com:overcast-software/career_caddy_e2e.git

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,19 @@ lint-automation: ## Ruff-lint automation (cc_auto) code
 test-automation: ## Run pytest in automation (cc_auto)
 	$(MAKE) -C automation test
 
+# e2e/ is an optional submodule. Skips cleanly when uninit so forks
+# without an e2e clone don't see CI red.
+canary: ## Cypress canary vs https://careercaddy.dev. Override target with CYPRESS_BASE_URL=...
+	@if [ -f e2e/package.json ]; then \
+		cd e2e && npm ci && npm run canary; \
+	else \
+		echo "e2e/ submodule not initialized — skipping canary (run 'git submodule update --init e2e' to enable)"; \
+	fi
+
+install-hooks: ## Wire scripts/git-hooks/ as the active hooks dir. Enables the pre-push canary against cc.dev.
+	git config core.hooksPath scripts/git-hooks
+	@echo "Hooks installed. Bypass once with: CC_SKIP_CANARY=1 git push"
+
 # ── CI (Dagger) ────────────────────────────────────────────────────────────
 # Requires Dagger CLI: curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
 #

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Pre-push gate: run the Cypress canary against cc.dev before
+# pushing to main. Nonzero exit blocks the push so a broken staging
+# state can't escalate into a prod Deploy.
+#
+# Activate with: make install-hooks
+# Bypass once:   CC_SKIP_CANARY=1 git push
+#
+# Pushes to non-main refs are unaffected.
+
+set -euo pipefail
+
+if [ "${CC_SKIP_CANARY:-0}" = "1" ]; then
+  echo "[pre-push] CC_SKIP_CANARY=1 — skipping canary."
+  exit 0
+fi
+
+target_main=false
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  if [ "$remote_ref" = "refs/heads/main" ]; then
+    target_main=true
+  fi
+done
+
+if [ "$target_main" = "false" ]; then
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+if [ ! -f "$repo_root/e2e/package.json" ]; then
+  echo "[pre-push] e2e/ submodule not initialized — skipping canary."
+  echo "[pre-push] Run 'git submodule update --init e2e' to enable."
+  exit 0
+fi
+
+base_url="${CYPRESS_BASE_URL:-https://careercaddy.dev}"
+echo "[pre-push] Running Cypress canary against $base_url ..."
+
+cd "$repo_root/e2e"
+if [ ! -d node_modules ]; then
+  npm ci
+fi
+CYPRESS_BASE_URL="$base_url" npm run canary


### PR DESCRIPTION
## Summary

- New optional submodule `e2e/` → `github.com/overcast-software/career_caddy_e2e` holding a Cypress canary.
- New `scripts/git-hooks/pre-push` runs the canary against cc.dev before any push to `main`. Nonzero exit blocks the push so a broken staging state can't escalate into a prod Deploy.
- New Makefile targets: `make canary` (manual run) and `make install-hooks` (one-time wiring of `core.hooksPath`).

## What the canary covers

Public surface only — no auth, no fixtures, no demo-data dependency:

- `GET /` responds non-5xx
- `GET /login` renders a password input
- `GET /docs` renders without an `Application Error`
- `GET /api/v1/healthcheck/` returns JSON with a `status` field
- `GET /api/v1/initialize/` reports `bootstrap_open=false`

The 2026-06-10 caddy outage (admin :2019 dead, all `/api/*` silently 301'd to apex) is the class of failure specs 4 and 5 exist to catch.

## How the gate fires

```
make install-hooks                      # one-time
git push origin main                    # runs canary first; blocks on red
CC_SKIP_CANARY=1 git push origin main   # bypass once (escape hatch)
git push origin feature/foo             # no canary; feature branches unaffected
```

Default target is `https://careercaddy.dev`. Override with `CYPRESS_BASE_URL=...`.

## OSS-opt-in

- Hook script is shipped in-tree but inert until `make install-hooks` runs `git config core.hooksPath scripts/git-hooks`. Forks that don't run it see unchanged push behavior.
- Submodule is optional. Hook + Makefile target skip cleanly when `e2e/` isn't initialized.

## Test plan

- [ ] `make install-hooks` and confirm the next `git push origin main` invokes the canary.
- [ ] Run `make canary` directly against cc.dev to confirm the 5 specs currently pass.
- [ ] Confirm `CC_SKIP_CANARY=1 git push origin main` bypasses cleanly.
- [ ] Confirm a push to a feature branch does not fire the canary.