### PR TITLE
chore(prod): bump api gunicorn workers 2 -> 4

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,7 +70,7 @@ services:
       BOOTSTRAP_TOKEN: ${BOOTSTRAP_TOKEN:-}
       GUNICORN_HOST: "0.0.0.0"
       GUNICORN_PORT: "8000"
-      GUNICORN_WORKERS: "2"
+      GUNICORN_WORKERS: "4"
       SA_SCHEMA_ON_POST_MIGRATE: "True"
       USE_MCP_BROWSER_AGENT: "False"
       CHAT_SERVICE_URL: "http://chat:8000"


### PR DESCRIPTION
## Summary

Analytics moved off racknerd earlier today (Plausible → omarchy), freeing CPU + ~500m of `mem_limit` budget. api is lagging on response time; bumping `GUNICORN_WORKERS` from 2 to 4 doubles concurrent request capacity.

## Sizing math

- racknerd: 4 CPU cores, 4.4 GB RAM (~2.2 GB free)
- Each gunicorn sync worker: ~100-120 MB resident (Django + SQLAlchemy + logfire)
- 4 workers ≈ 500 MB; api `mem_limit` already at 768m — no bump needed
- Concurrent request capacity: 2 → 4

## What this is NOT

Not threading. `api/gunicorn.conf.py` uses sync workers only (no `threads` support). Adding threads would require an api submodule PR + new env var. If `workers=4` doesn't unstick latency, threading is the next step.

## Test plan

- [ ] After Deploy: `time curl https://careercaddy.online/api/v1/healthcheck/` returns faster than before.
- [ ] Confirm 4 gunicorn worker processes running: `ssh rn 'docker exec careercaddy-api ps -ef | grep gunicorn'`.
- [ ] Watch api `mem_limit` headroom — should stay well under 768m at steady state.