### PR TITLE
chore(prod): enable gthread on api — 4 workers x 2 threads = 8 concurrent

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,6 +71,7 @@ services:
       GUNICORN_HOST: "0.0.0.0"
       GUNICORN_PORT: "8000"
       GUNICORN_WORKERS: "4"
+      GUNICORN_THREADS: "2"
       SA_SCHEMA_ON_POST_MIGRATE: "True"
       USE_MCP_BROWSER_AGENT: "False"
       CHAT_SERVICE_URL: "http://chat:8000"


### PR DESCRIPTION
## Summary

Pairs with api PR #174 just merged.

api pin: `3e8e447 → 86c3950` (gthread support added).
docker-compose.prod.yml: `GUNICORN_THREADS=2` added alongside existing `GUNICORN_WORKERS=4`.

Net concurrent request capacity:

| | workers | threads | concurrent | worker class |
|--|--|--|--|--|
| before this morning | 2 | 1 | 2 | sync |
| after #266 (workers=4) | 4 | 1 | 4 | sync |
| after this PR | 4 | 2 | **8** | gthread |

## Memory

Threads cost a per-thread stack (~1MB) on top of the existing worker process. 4 workers × 2 threads × 1MB stacks ≈ 8MB additional — well within the existing 768m mem_limit. Each worker is still ~120-150MB resident.

## Test plan

- [ ] After Deploy: `ssh rn 'docker exec careercaddy-api ps -ef | grep gunicorn'` shows 4 worker procs with `--worker-class gthread --threads 2` in the command line.
- [ ] api latency drops noticeably under your usual concurrent load.
- [ ] No SSE regressions (frontend live-update of scrape status etc still works).