### PR TITLE
chore(deploy): drop --app-dir override, use git-tracked dagger default

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,11 +59,16 @@ jobs:
           GHCR_TOKEN: ${{ github.token }}
 
       - name: Deploy to VPS
+        # app_dir is intentionally NOT passed here. The deploy target lives in
+        # the dagger default (career_caddy_pipeline.py:498 ->
+        # /opt/stacks/careercaddy.online) so it is version-controlled and
+        # auditable. Threading it via a DEPLOY_APP_DIR secret previously drifted
+        # to a stale legacy path and broke every Deploy (5432 collision); the
+        # single source of truth removes that footgun.
         run: |
           dagger -m ./dagger call deploy \
             --ssh-key=env:DEPLOY_SSH_KEY \
             --host=${{ secrets.DEPLOY_SSH_HOST }} \
-            --app-dir=${{ secrets.DEPLOY_APP_DIR }} \
             --tag=${{ github.sha }} \
             --ssh-user=${{ secrets.DEPLOY_SSH_USER }}
         env:


### PR DESCRIPTION
## What

Removes the `--app-dir=${{ secrets.DEPLOY_APP_DIR }}` override from the "Deploy to VPS" step in `deploy.yml`. The deploy target is now solely the dagger `deploy()` default — `/opt/stacks/careercaddy.online` (`dagger/src/career_caddy_pipeline.py:498`) — so it is version-controlled and auditable.

## Why

The original todo ("Fix or retire GH Actions Deploy workflow — currently targets dead Projects dir") was filed when `DEPLOY_APP_DIR` pointed at the legacy `/home/oldbones/Projects/career_caddy/`, which collided with the real prod Postgres on 5432 and failed every Deploy.

That acute bug is **already resolved** in prod (the secret was repointed and `2b6bb8f` realigned the dagger default). Verified 2026-06-16: prod runs `IMAGE_TAG=75ecb21` (latest merged main) with all containers sourced from `/opt/stacks/careercaddy.online`.

This PR closes the **root cause**: a deploy target split between a git-tracked default and an out-of-band secret is exactly the drift that broke deploys. With the override gone, the target lives in one place — the dagger pipeline.

## Risk

Low. `DEPLOY_APP_DIR` is the only consumer (grep-confirmed), and the dagger default already matches the verified live prod path. After merge the next Deploy targets the same `/opt/stacks/careercaddy.online` it does today. `DEPLOY_APP_DIR` becomes unused and can be deleted from repo secrets later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)