### PR TITLE
fix(worker): disable inherited api healthcheck on django-q worker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -122,6 +122,16 @@ services:
       - default
     entrypoint: ""
     command: python manage.py qcluster
+    # The shared api image ships a HEALTHCHECK (api/Dockerfile) that curls
+    # http://127.0.0.1:8000/api/v1/healthcheck — correct for the gunicorn api,
+    # but the worker runs qcluster with no HTTP surface, so the probe can never
+    # connect and the container reports "unhealthy" forever despite processing
+    # tasks fine. No cheap worker-side probe catches the real failure mode (DB
+    # unreachable / cluster wedged), so disable the inherited check rather than
+    # ship a green-theater one. Liveness is covered by restart:unless-stopped +
+    # qcluster reincarnation; processing is observable via django_q_task.
+    healthcheck:
+      disable: true
     environment:
       DEBUG: "False"
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,11 @@ services:
       context: ./api
     entrypoint: ""
     command: python manage.py qcluster
+    # Same image as api, which ships a HEALTHCHECK curling :8000. The worker has
+    # no HTTP surface, so the inherited probe always fails and the container
+    # shows "unhealthy". Disable it here too (parity with docker-compose.prod.yml).
+    healthcheck:
+      disable: true
     volumes:
       - ./api:/app
       - api_venv:/app/.venv


### PR DESCRIPTION
## What

Adds `healthcheck: { disable: true }` to the `worker` service in both `docker-compose.prod.yml` and `docker-compose.yml`.

## Why

`careercaddy-worker` has shown `Up (unhealthy)` continuously since boot (`FailingStreak: 8732` = every 30s probe since the container started). Root cause: the worker shares the **api image**, whose `Dockerfile` `HEALTHCHECK` curls `http://127.0.0.1:8000/api/v1/healthcheck`. That's correct for the gunicorn api, but the worker runs `manage.py qcluster` with **no HTTP surface**, so every probe is connection-refused.

The worker itself is **fine** — verified on prod 2026-06-16 that `django_q_task` shows the interval sweeps (`federation_dispatch_sweep`, `sweep_stale_scrape_claims`) completing every minute, all `success`. The `unhealthy` flag was pure healthcheck mismatch, never a functional fault. (A one-off `could not translate host name db` on 2026-06-15 was transient fallout from the disk-full/docker-instability window; `db` resolves now and the cluster self-recovered.)

## Why disable rather than replace

No cheap worker-side probe catches the real failure mode (DB unreachable / cluster wedged); a process-liveness check would be green-theater. Liveness is already covered by `restart: unless-stopped` + qcluster's reincarnation, and actual processing is observable via `django_q_task`. A disabled check is more honest than a perma-red or always-green one.

## Risk

Low. Only changes the worker's reported health status; no behavior, image, or DB change. Applies on next deploy (prod) / `make up` (dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)