### PR TITLE
feat(deploy): split SSE stream onto a separate ASGI events service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,11 @@ jobs:
   ci:
     name: Build and test (API + Frontend)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 40, not 20: the SSE split added uvicorn[standard] (native uvloop/httptools
+    # compiles) + django-q2 to the api image, pushing the cold `build-api` step
+    # (uv sync + full Django suite) past the old 20m cap on its own — frontend +
+    # AI steps never got to run. Real fix is Dagger uv-dep caching; this unblocks.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,7 @@ jobs:
   ci:
     name: Build and test (API + Frontend)
     runs-on: ubuntu-latest
-    # 40, not 20: the SSE split added uvicorn[standard] (native uvloop/httptools
-    # compiles) + django-q2 to the api image, pushing the cold `build-api` step
-    # (uv sync + full Django suite) past the old 20m cap on its own — frontend +
-    # AI steps never got to run. Real fix is Dagger uv-dep caching; this unblocks.
-    timeout-minutes: 40
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,7 @@ jobs:
   ci:
     name: Build and test (API + Frontend)
     runs-on: ubuntu-latest
-    # 40, not 20: matches ci.yml — the SSE-weight api image (uvicorn[standard] +
-    # django-q2) makes the cold build-api step exceed 20m on its own. Without
-    # this bump the post-merge Deploy gate would time out and never deploy.
-    timeout-minutes: 40
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,9 +34,7 @@ jobs:
     name: Publish images and deploy to VPS
     runs-on: ubuntu-latest
     environment: production
-    # 40, not 30: the cold api image build for GHCR publish carries the same
-    # heavier SSE deps; give the build+publish+deploy chain headroom.
-    timeout-minutes: 40
+    timeout-minutes: 30
     needs: ci
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,10 @@ jobs:
   ci:
     name: Build and test (API + Frontend)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 40, not 20: matches ci.yml — the SSE-weight api image (uvicorn[standard] +
+    # django-q2) makes the cold build-api step exceed 20m on its own. Without
+    # this bump the post-merge Deploy gate would time out and never deploy.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,7 +37,9 @@ jobs:
     name: Publish images and deploy to VPS
     runs-on: ubuntu-latest
     environment: production
-    timeout-minutes: 30
+    # 40, not 30: the cold api image build for GHCR publish carries the same
+    # heavier SSE deps; give the build+publish+deploy chain headroom.
+    timeout-minutes: 40
     needs: ci
     steps:
       - uses: actions/checkout@v4

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -101,10 +101,56 @@ services:
     labels:
       caddy: api.careercaddy.online
       caddy.import: cc_log
+      # The SSE stream runs on the separate ASGI `events` service (uvicorn,
+      # off the sync gunicorn pool) so a long-lived stream can't peg/SIGKILL
+      # an api worker — see api notes Plans/SSE off sync gunicorn (Option B).
+      # EXACT-path match (no trailing *) so POST /api/v1/events/token/ stays
+      # on the gunicorn api; only GET /api/v1/events/ (the stream) is split
+      # off. flush_interval -1 disables proxy buffering for text/event-stream.
+      # Mirrors the proven handle_N pattern on the frontend service below.
+      caddy.handle_0: /api/v1/events/
+      caddy.handle_0.reverse_proxy: events:8001
+      caddy.handle_0.reverse_proxy.flush_interval: "-1"
       caddy.reverse_proxy: "{{upstreams 8000}}"
       caddy.reverse_proxy.transport: http
       caddy.reverse_proxy.transport.read_timeout: 2m
       caddy.reverse_proxy.transport.write_timeout: 2m
+
+  # ── Events (SSE) ──────────────────────────────────────────────────────────
+  # Separate ASGI process serving ONLY the long-lived SSE stream
+  # (GET /api/v1/events/). Shares the api image (same SHA/code/env) but runs
+  # uvicorn instead of gunicorn, so the stream lives off the sync gunicorn
+  # pool: uvicorn has no arbiter SIGKILL, so a >120s stream survives and one
+  # stuck stream can't halve api request capacity. caddy routes the exact
+  # path /api/v1/events/ here (see the api service labels); the token POST
+  # and everything else stay on the gunicorn api. Option B of the api notes
+  # Plans/SSE off sync gunicorn — A-B-C tradeoff.
+  events:
+    image: ghcr.io/overcast-software/career_caddy_api:${IMAGE_TAG:-latest}
+    container_name: careercaddy-events
+    restart: unless-stopped
+    networks:
+      - default   # reach db for the LISTEN connection
+      - proxy     # so caddy resolves `events` as the SSE upstream
+    entrypoint: ""
+    command: ["uvicorn", "job_hunting.sse_asgi:app", "--host", "0.0.0.0", "--port", "8001"]
+    environment:
+      DEBUG: "False"
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
+      DATABASE_URL: postgresql://${DB_USER:-postgres}:${DB_PASSWORD}@db:5432/${DB_NAME:-job_hunting}
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-careercaddy.online,api.careercaddy.online,localhost,127.0.0.1,events}
+      SA_SCHEMA_ON_POST_MIGRATE: "False"  # api runs migrations; events just LISTENs
+      LOGFIRE_TOKEN: ${LOGFIRE_TOKEN:-}
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8001/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+    mem_limit: 256m
 
   # ── Worker ──────────────────────────────────────────────────────────────
   # django-q2 task worker — Phase 1 of Plans/Job-queue integration. Shares

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,42 @@ services:
       db:
         condition: service_healthy
 
+  # ── Events (SSE) ──────────────────────────────────────────────────────────
+  # ASGI SSE process (uvicorn) serving GET /api/v1/events/. Shares the api
+  # image/venv but runs off the sync gunicorn pool — see api notes
+  # Plans/SSE off sync gunicorn (Option B). Locally there is no caddy, so the
+  # Ember frontend still hits the sync events.py path on :8000; this service
+  # is exposed on :8001 to exercise the ASGI app directly
+  # (curl 'http://localhost:8001/api/v1/events/?token=...'). Needs `make build`
+  # after the pyproject adds uvicorn/starlette so they land in the api_venv.
+  events:
+    build:
+      context: ./api
+    entrypoint: ""
+    command: ["uvicorn", "job_hunting.sse_asgi:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]
+    volumes:
+      - ./api:/app
+      - api_venv:/app/.venv
+      - screenshots:/app/screenshots
+    ports:
+      - "8001:8001"
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@db:5432/${DB_NAME:-job_hunting}
+      DEBUG: "True"
+      SECRET_KEY: ${SECRET_KEY:-dev-only-insecure-do-not-use-in-production}
+      ALLOWED_HOSTS: "localhost,127.0.0.1,events"
+      SA_SCHEMA_ON_POST_MIGRATE: "False"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8001/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+    depends_on:
+      db:
+        condition: service_healthy
+
   # ── Worker ──────────────────────────────────────────────────────────────
   # django-q2 task worker — Phase 1 of Plans/Job-queue integration. Shares
   # the api image (same code, same venv, same env). Runs `manage.py qcluster`


### PR DESCRIPTION
Ships Option B for SSE off the sync gunicorn pool (api notes Plans/SSE off sync gunicorn — A-B-C tradeoff). Pairs the api-side ASGI module (api #184) with the parent compose + caddy wiring.

Why: the 2026-06-10 racknerd incident wedged a sync gunicorn worker for the full 120s GUNICORN_TIMEOUT (arbiter SIGKILL, closed_by=unknown at 120129ms) — sync workers do not reset the arbiter heartbeat between streaming yields, so a long SSE stream dies and one stuck stream can halve api capacity.

What:
- api pin -> 004b112 (#184): adds job_hunting/sse_asgi.py, a Starlette/uvicorn ASGI app serving only GET /api/v1/events/ (the stream) plus GET /healthz on :8001, reusing the existing events.py token/LISTEN/filter logic. No duration cap — uvicorn has no arbiter SIGKILL. The token POST (/api/v1/events/token/) and everything else stay on the gunicorn api.
- compose + caddy (cherry-picked d17f657): new events service (shared api image, runs uvicorn on :8001); caddy routes the exact path /api/v1/events/ to it (no trailing wildcard, so the token POST stays on gunicorn); flush_interval -1 disables proxy buffering for text/event-stream. Local compose exposes :8001 for direct testing.

Notes:
- Built on current main (post known-good epic, e7d2435); only the api pin moves — frontend/automation/agents stay at their epic pins. No conflict.
- Supersedes the Option C stopgap (api #164, duration cap) — that PR should be closed.