### PR TITLE
ci(deploy): retag unchanged-submodule images instead of rebuilding (PACA #8 lever B)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,21 +40,63 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          # Full history so we can diff the previous main tip against this
+          # push to see which submodule pins actually moved.
+          fetch-depth: 0
 
       - name: Install Dagger CLI
         run: curl -fsSL https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=v0.20.8 BIN_DIR=/usr/local/bin sh
+
+      - name: Detect changed submodule pins
+        id: changed
+        # Compute which submodule gitlinks moved between the previous main tip
+        # (github.event.before) and this push (github.sha), mapping
+        # api->api, frontend->frontend, agents->ai. publish() then cold-builds
+        # only the changed images and retags the rest from prev_tag.
+        #
+        # FAIL SAFE: if `before` is all-zeros (first push), empty, or not a
+        # reachable ancestor (force-push / shallow / rewritten history) we
+        # cannot trust the diff, so we emit prev="" and changed=all three —
+        # forcing publish() to build every image (today's behavior).
+        run: |
+          BEFORE='${{ github.event.before }}'
+          SHA='${{ github.sha }}'
+          ZERO='0000000000000000000000000000000000000000'
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "$ZERO" ] || ! git merge-base --is-ancestor "$BEFORE" "$SHA" 2>/dev/null; then
+            echo "Previous sha unusable ($BEFORE) — fail-safe: building all images."
+            echo "prev=" >> "$GITHUB_OUTPUT"
+            echo "changed=api,frontend,ai" >> "$GITHUB_OUTPUT"
+          else
+            PATHS="$(git diff --name-only "$BEFORE" "$SHA" -- api frontend agents)"
+            echo "Changed gitlinks between $BEFORE and $SHA:"
+            echo "$PATHS"
+            CHANGED=""
+            echo "$PATHS" | grep -qx api && CHANGED="$CHANGED,api"
+            echo "$PATHS" | grep -qx frontend && CHANGED="$CHANGED,frontend"
+            echo "$PATHS" | grep -qx agents && CHANGED="$CHANGED,ai"
+            CHANGED="${CHANGED#,}"
+            echo "prev=$BEFORE" >> "$GITHUB_OUTPUT"
+            echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+            echo "Resolved changed images: '$CHANGED'"
+          fi
 
       - name: Publish images to GHCR
         # Frontend builds with API_HOST="" (same-origin default). The SPA
         # emits /api/v1/... to its own host; racknerd's outer Caddy routes
         # /api/* on careercaddy.online to the api container via the
         # handle /api/* label on the frontend service.
+        #
+        # --changed / --prev-tag drive the build-changed / retag-unchanged
+        # split. Empty --changed with a real --prev-tag retags all three
+        # (parent-only push, no pin moved); empty --prev-tag builds all.
         run: |
           dagger -m ./dagger call publish \
             --registry-token=env:GHCR_TOKEN \
             --org=overcast-software \
             --tag=${{ github.sha }} \
-            --registry-username=${{ github.actor }}
+            --registry-username=${{ github.actor }} \
+            --prev-tag="${{ steps.changed.outputs.prev }}" \
+            --changed="${{ steps.changed.outputs.changed }}"
         env:
           GHCR_TOKEN: ${{ github.token }}
 

--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -423,6 +423,62 @@ class CareerCaddy:
             .with_exec(["uv", "run", "pytest", "tests/", "-v"])
         )
 
+    async def _build_publish(
+        self,
+        src: dagger.Directory,
+        ref: str,
+        username: str,
+        registry_token: Secret,
+        build_args: list | None,
+        build_kwargs: dict,
+    ) -> str:
+        """Cold-build `src` and push it to `ref`. Returns the pushed ref."""
+        kwargs = dict(build_kwargs)
+        if build_args:
+            kwargs["build_args"] = build_args
+        return await (
+            src
+            .docker_build(**kwargs)
+            .with_registry_auth(REGISTRY, username, registry_token)
+            .publish(ref)
+        )
+
+    async def _retag(
+        self,
+        repo: str,
+        prev_tag: str,
+        tag: str,
+        username: str,
+        registry_token: Secret,
+    ) -> str:
+        """Copy `{repo}:{prev_tag}` → `{repo}:{tag}` in GHCR without rebuilding.
+
+        Uses crane (server-side manifest copy — no image pull/push of layers,
+        and platform-agnostic: it copies whatever the prev manifest was). The
+        `:debug` image is required because `crane auth login --password-stdin`
+        needs a shell to read the mounted token from stdin; the default crane
+        image is distroless with no shell.
+
+        Forces execution via `.sync()` so any failure (missing prev image,
+        auth error, network) raises — the caller catches and falls back to a
+        cold build, so a tag is NEVER left stale or missing.
+        """
+        src_ref = f"{repo}:{prev_tag}"
+        dst_ref = f"{repo}:{tag}"
+        await (
+            dag.container()
+            .from_("gcr.io/go-containerregistry/crane:debug")
+            .with_mounted_secret("/run/secrets/ghcr_token", registry_token)
+            .with_exec([
+                "sh", "-c",
+                f"crane auth login {REGISTRY} -u {username} --password-stdin "
+                f"< /run/secrets/ghcr_token "
+                f"&& crane copy {src_ref} {dst_ref}",
+            ])
+            .sync()
+        )
+        return dst_ref
+
     @function
     async def publish(
         self,
@@ -435,8 +491,27 @@ class CareerCaddy:
         registry_username: str = "",
         platform: str = "",
         frontend_api_host: str = "",
+        prev_tag: str = "",
+        changed: str = "api,frontend,ai",
     ) -> list[str]:
-        """Build all images and push to GHCR. Returns list of pushed image refs.
+        """Build changed images, retag unchanged ones, push to GHCR.
+
+        On a parent-main push that only bumped some submodule pins, the
+        unchanged submodules' images are byte-identical to the previous
+        deploy, so we copy (`crane copy`) the already-published
+        `{repo}:{prev_tag}` to `{repo}:{tag}` instead of cold-rebuilding —
+        keeping the single parent-SHA `IMAGE_TAG` contract (no
+        docker-compose.prod.yml change). Returns the list of resulting refs.
+
+        FAIL SAFE — an image reaches `:{tag}` only by (a) a fresh build, or
+        (b) a retag from a prev tag whose pin was byte-identical. Two layers:
+          1. `prev_tag == ""` forces a build for every image (the all-zeros /
+             first-push / force-push guard sets this in the workflow).
+          2. `changed` defaults to all three images, so any mis-call or empty
+             arg reproduces today's build-everything behavior.
+          3. If a retag throws for ANY reason (prev image missing, auth,
+             network) the per-image path falls back to a cold build.
+        Never stale, never missing.
 
         Args:
             registry_token: GitHub token with packages:write permission
@@ -449,42 +524,61 @@ class CareerCaddy:
                 build. Default is empty → same-origin (SPA emits /api/v1/...;
                 outer proxy routes /api/* to the api container). Pass a full
                 origin only for explicit cross-origin deployments.
+            prev_tag: Image tag of the previous deploy (the parent SHA before
+                this push). Empty → build every image (safe default).
+            changed: Comma list of image names that changed this push
+                (api / frontend / ai). Defaults to all three. The workflow
+                maps the changed submodule gitlinks (api→api, frontend→
+                frontend, agents→ai) into this list.
         """
         username = registry_username or org
-        api_ref = f"{REGISTRY}/{org}/{API_IMAGE}:{tag}"
-        frontend_ref = f"{REGISTRY}/{org}/{FRONTEND_IMAGE}:{tag}"
-        ai_ref = f"{REGISTRY}/{org}/{AI_IMAGE}:{tag}"
+        api_repo = f"{REGISTRY}/{org}/{API_IMAGE}"
+        frontend_repo = f"{REGISTRY}/{org}/{FRONTEND_IMAGE}"
+        ai_repo = f"{REGISTRY}/{org}/{AI_IMAGE}"
+
+        changed_set = {c.strip() for c in changed.split(",") if c.strip()}
 
         build_kwargs: dict = {}
         if platform:
             build_kwargs["platform"] = dagger.Platform(platform)
 
-        pushed_api = await (
-            api_src
-            .docker_build(**build_kwargs)
-            .with_registry_auth(REGISTRY, username, registry_token)
-            .publish(api_ref)
-        )
+        async def resolve(
+            name: str,
+            src: dagger.Directory,
+            repo: str,
+            build_args: list | None,
+        ) -> str:
+            ref = f"{repo}:{tag}"
+            # Build when there is no previous tag to copy from, or when this
+            # image's pin actually changed this push.
+            if not prev_tag or name in changed_set:
+                return await self._build_publish(
+                    src, ref, username, registry_token, build_args, build_kwargs
+                )
+            # Unchanged pin → retag prev→tag; fall back to a build on ANY
+            # failure so the tag is never left stale or missing.
+            try:
+                return await self._retag(
+                    repo, prev_tag, tag, username, registry_token
+                )
+            except Exception:
+                return await self._build_publish(
+                    src, ref, username, registry_token, build_args, build_kwargs
+                )
 
-        pushed_frontend = await (
-            frontend_src
-            .docker_build(
-                build_args=[dagger.BuildArg("API_HOST", frontend_api_host)],
-                **build_kwargs,
-            )
-            .with_registry_auth(REGISTRY, username, registry_token)
-            .publish(frontend_ref)
+        pushed_api = await resolve("api", api_src, api_repo, None)
+        pushed_frontend = await resolve(
+            "frontend",
+            frontend_src,
+            frontend_repo,
+            [dagger.BuildArg("API_HOST", frontend_api_host)],
         )
-
         # AI image: build without Camoufox (browser runs on Pi, not VPS)
-        pushed_ai = await (
-            ai_src
-            .docker_build(
-                build_args=[dagger.BuildArg("INSTALL_CAMOUFOX", "false")],
-                **build_kwargs,
-            )
-            .with_registry_auth(REGISTRY, username, registry_token)
-            .publish(ai_ref)
+        pushed_ai = await resolve(
+            "ai",
+            ai_src,
+            ai_repo,
+            [dagger.BuildArg("INSTALL_CAMOUFOX", "false")],
         )
 
         return [pushed_api, pushed_frontend, pushed_ai]


### PR DESCRIPTION
## PACA #8 lever B — skip rebuilding unchanged-submodule images on Deploy

On a parent-`main` push that only bumped some submodule pins, build + publish **only** the changed submodules' images; for unchanged ones, **retag the previously-published image** to the new parent-SHA tag. The single parent-SHA `IMAGE_TAG` contract is unchanged — **no `docker-compose.prod.yml` change.** A typical single-submodule pin bump goes from 3 cold builds → 1.

### What changed

**`.github/workflows/deploy.yml`** (`publish-and-deploy` job):
- `fetch-depth: 0` on the checkout (need history to diff).
- New `Detect changed submodule pins` step: diffs `github.event.before`→`github.sha` over the `api frontend agents` gitlinks, maps `api`→`api`, `frontend`→`frontend`, `agents`→`ai`, and emits `changed` + `prev` step-outputs.
- **GUARD:** if `before` is empty, all-zeros (`0000...`), or not a reachable ancestor of `sha` (first push / force-push / shallow), it emits `prev=""` and `changed=api,frontend,ai` — forcing a full build of everything (today's behavior).
- The publish call now threads `--prev-tag` and `--changed`.

**`dagger/src/career_caddy_pipeline.py`** (`publish()` only):
- New params `prev_tag: str = ""` and `changed: str = "api,frontend,ai"`. **Defaults = build all**, so any mis-call or empty arg reproduces today's behavior.
- Per image (api / frontend / ai): **build+publish** if its name is in the `changed` set OR `prev_tag` is empty; ELSE **retag** `{repo}:{prev_tag}`→`{repo}:{tag}` via `crane copy`. The retag await is wrapped in `try/except` → on **any** exception it falls back to a cold build.
- Two private helpers: `_build_publish()` (the existing build+publish path, factored out) and `_retag()` (crane container authed to GHCR with the mounted token, `.sync()` to force evaluation so failures raise).
- `make ci` functions (`build_api`/`build_frontend`/`build_ai`/`test_*`) are untouched.

### Fail-safe (non-negotiable, this is the prod Deploy)

An image reaches `:{tag}` only by **(a)** a fresh build, or **(b)** a retag from a prev tag whose pin was byte-identical. Three layers:
1. `prev_tag == ""` forces a build for every image (the workflow guard sets this).
2. `changed` defaults to all three images.
3. Any retag exception (prev image missing, auth, network) → cold build.

Never stale, never missing.

### Verification (and its limits)

Dagger is **not installed on this workstation**, and `publish()` pushes to **real GHCR** — so I did **not** run `dagger functions` / `dagger call publish --help` / a real publish. Full publish+retag validation happens on the **next real Deploy**, de-risked by (a) fail-safe-to-build and (b) the build-all default.

What I did verify locally:

- **Module compiles:** `python3 -m py_compile dagger/src/career_caddy_pipeline.py` → OK. (`make ci` runs the ~9-min API suite and does not exercise `publish()`, so it was not re-run; the build/test path is byte-unchanged.)
- **Workflow YAML parses:** `yaml.safe_load(deploy.yml)` → OK.
- **Pin-detection logic** (`git diff --name-only <before> <sha> -- api frontend agents`):

```
# api + frontend pin bump (HEAD~1 = #290 merge):
$ git diff --name-only HEAD~1 HEAD -- api frontend agents
api
frontend
  -> changed=api,frontend  (build api+frontend, retag ai)

# agents-only pin bump (f45bc20):
$ git diff --name-only f45bc20~1 f45bc20 -- api frontend agents
agents
  -> agents maps to ai, changed=ai  (build ai only, retag api+frontend)
  -> 3 cold builds become 1
```

- **crane retag mechanics** (inspected the public `gcr.io/go-containerregistry/crane:debug` image — no GHCR push):
  - PATH includes `/busybox` (so `sh` resolves) and `crane` is on PATH at `/ko-app/crane`.
  - `crane auth login ghcr.io -u <user> --password-stdin < /run/secrets/token && crane copy ...` works under busybox `sh` (stdin redirect + `&&` chain confirmed). `crane auth login` stores creds without validating, so a bad token still fails at `crane copy` → non-zero exit → `.sync()` raises → fail-safe to build. (`:debug` is required: the default crane image is distroless with no shell for `--password-stdin`.)

### Secondary note — lever A (registry layer-cache) feasibility, NOT implemented here

Dagger v0.20.8's `Directory.docker_build()` does **not** expose BuildKit registry `cache-from`/`cache-to` arguments — its params are `dockerfile` / `platform` / `build_args` / `target` / `secrets`. Dagger relies on its own engine-side content-addressed layer cache rather than a registry-backed BuildKit cache. So lever A would be a different shape than "pass `cache-from`/`cache-to`": it'd mean persisting Dagger's engine cache across CI runs (cache volume / Dagger Cloud / a persistent engine) rather than a `docker_build()` kwarg. Worth confirming against the v0.20.8 SDK before the follow-up; flagging as feasibility only, no code here.

### Ship discipline

Build-don't-ship: opening this PR, **not merging**. Parent-only change (no submodule source touched).
