### PR TITLE
ci(smoke): post-deploy + scheduled prod smoke, make smoke target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,3 +115,39 @@ jobs:
             --ssh-user=${{ secrets.DEPLOY_SSH_USER }}
         env:
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      # Post-deploy smoke. `docker compose up -d` returns before the
+      # containers are actually serving, so poll the api healthcheck first,
+      # then run Tier 1 (public) + Tier 2 (authed MCP handshake + /me/)
+      # against prod. A red smoke fails the Deploy run so the breakage is
+      # seen immediately. NOTE: detection, not prevention — there is no
+      # auto-rollback; recovery is still a manual pin-back. Tier 2 self-skips
+      # if CC_SMOKE_API_TOKEN is unset (Tier 1 still gates).
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Wait for prod to settle
+        run: |
+          for i in $(seq 1 30); do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' https://api.careercaddy.online/api/v1/healthcheck/ || true)
+            if [ "$code" = "200" ]; then echo "api healthy"; exit 0; fi
+            echo "waiting for api ($code)…"; sleep 5
+          done
+          echo "api healthcheck never reached 200"; exit 1
+
+      - name: Post-deploy smoke (Tier 1 + Tier 2) against prod
+        working-directory: e2e
+        env:
+          CYPRESS_BASE_URL: https://careercaddy.online
+          CYPRESS_API_URL: https://api.careercaddy.online
+          CYPRESS_MCP_URL: https://mcp.careercaddy.online/mcp
+          CYPRESS_CC_API_TOKEN: ${{ secrets.CC_SMOKE_API_TOKEN }}
+          CC_API_TOKEN: ${{ secrets.CC_SMOKE_API_TOKEN }}
+          MCP_URL: https://mcp.careercaddy.online/mcp
+        run: |
+          npm ci
+          npm run smoke:tier1
+          npm run smoke:mcp
+          npm run smoke:tier2:api

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,77 @@
+name: Smoke
+
+# Demo-insurance: catch drift and silent outages (e.g. the 2026-06-22 MCP
+# verify-flap) BETWEEN deploys, before they surface mid-demo. Also a
+# "run now" button (workflow_dispatch) to confirm prod is green right
+# before a demo. A failed scheduled run shows red in the Actions tab and
+# GitHub emails the workflow owner — that's the alerting today.
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Tier 1 + Tier 2 vs prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Smoke (Tier 1 public + Tier 2 authed)
+        working-directory: e2e
+        env:
+          CYPRESS_BASE_URL: https://careercaddy.online
+          CYPRESS_API_URL: https://api.careercaddy.online
+          CYPRESS_MCP_URL: https://mcp.careercaddy.online/mcp
+          CYPRESS_CC_API_TOKEN: ${{ secrets.CC_SMOKE_API_TOKEN }}
+          CC_API_TOKEN: ${{ secrets.CC_SMOKE_API_TOKEN }}
+          MCP_URL: https://mcp.careercaddy.online/mcp
+        run: |
+          npm ci
+          npm run smoke:tier1
+          npm run smoke:mcp
+          npm run smoke:tier2:api
+      # Active-alert upgrade (follow-up): post to Slack on failure once an
+      # incoming-webhook URL exists as a SLACK_WEBHOOK_URL secret.
+      # - name: Notify on failure
+      #   if: failure()
+      #   run: |
+      #     curl -fsS -X POST -H 'Content-type: application/json' \
+      #       -d '{"text":"🔴 Career Caddy smoke FAILED — run ${{ github.run_id }}"}' \
+      #       "${{ secrets.SLACK_WEBHOOK_URL }}"
+
+  adjacent:
+    name: Tier 3 adjacent (warn-only)
+    runs-on: ubuntu-latest
+    needs: smoke
+    # Run even if the gating smoke job failed, and never fail the run on a
+    # Tier 3 miss — metabase/plane are out of cc's repair lane.
+    if: always()
+    continue-on-error: true
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Tier 3 (metabase reachability)
+        working-directory: e2e
+        env:
+          CYPRESS_METABASE_URL: https://metabase.careercaddy.online
+        run: |
+          npm ci
+          npm run smoke:tier3

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,29 @@ install-hooks: ## Wire scripts/git-hooks/ as the active hooks dir. Enables the p
 	git config core.hooksPath scripts/git-hooks
 	@echo "Hooks installed. Bypass once with: CC_SKIP_CANARY=1 git push"
 
+# Demo-readiness smoke vs prod. Tier 1 (public) always runs; Tier 2 (MCP
+# handshake + authed API) runs only when CC_API_TOKEN is set. Tier 3
+# (adjacent/warn-only) is the scheduled workflow's job, not run here.
+# Same suite the post-deploy step and smoke.yml cron run — this is the
+# "about to demo, is it all green?" command.
+.PHONY: smoke
+smoke: ## Smoke vs prod (Tier1 always; Tier2 if CC_API_TOKEN set). Override CYPRESS_BASE_URL=...
+	@if [ ! -f e2e/package.json ]; then \
+		echo "e2e/ submodule not initialized — run 'git submodule update --init e2e' to enable smoke"; \
+	else \
+		base="$${CYPRESS_BASE_URL:-https://careercaddy.online}"; \
+		api="$${CYPRESS_API_URL:-https://api.careercaddy.online}"; \
+		mcp="$${MCP_URL:-https://mcp.careercaddy.online/mcp}"; \
+		cd e2e && npm ci && \
+		CYPRESS_BASE_URL="$$base" CYPRESS_API_URL="$$api" CYPRESS_MCP_URL="$$mcp" npm run smoke:tier1 && \
+		if [ -n "$$CC_API_TOKEN" ]; then \
+			MCP_URL="$$mcp" npm run smoke:mcp && \
+			CYPRESS_BASE_URL="$$base" CYPRESS_API_URL="$$api" CYPRESS_CC_API_TOKEN="$$CC_API_TOKEN" npm run smoke:tier2:api; \
+		else \
+			echo "CC_API_TOKEN not set — skipping Tier 2 (operator-only)."; \
+		fi; \
+	fi
+
 # ── CI (Dagger) ────────────────────────────────────────────────────────────
 # Requires Dagger CLI: curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
 #


### PR DESCRIPTION
## What

Wires the three automatic triggers for the e2e tiered smoke suite (overcast-software/career_caddy_e2e#2) so prod breakage surfaces **before** a demo instead of during one. Motivated by the 2026-06-22 public-MCP outage that nothing automated caught.

## Changes

- **deploy.yml** — after `Deploy to VPS`: poll the api healthcheck until prod settles, then run Tier 1 (public) + the full MCP handshake + authed `/me/` against prod. A red smoke fails the Deploy run.
- **smoke.yml** (new) — `schedule: */30` + `workflow_dispatch`. Demo-insurance that catches drift/flaps between deploys. A second `adjacent` job runs Tier 3 (metabase) with `continue-on-error` so an out-of-lane outage never turns the run red. Alerting is GitHub-native (red run + email); a Slack step is stubbed as a follow-up.
- **Makefile** — `make smoke` runs the same suite vs prod on demand (Tier 1 always; Tier 2 only when `CC_API_TOKEN` is set).
- **e2e pin** bumped `1fee635 → de7ac75` so the `smoke:*` scripts exist at the checked-out submodule.

## Merge ordering (important)

1. Merge e2e #2 → e2e `main` first (it includes the canary contract fix from e2e #1).
2. Re-point this PR's e2e pin to the resulting e2e-`main` tip if the merge SHA differs (a merge-commit keeps `de7ac75` reachable from main, so the pin stays valid; a squash would need a re-pin).
3. **Merging this parent PR to `main` triggers Deploy** — that deploy runs the new post-deploy smoke as its first live exercise. Hold for an explicit ship.

## Required before the authed tier runs

Add a GitHub Actions secret **`CC_SMOKE_API_TOKEN`** = a dedicated, least-privilege, revocable **prod** `jh_*` key, at **repo level** (for `smoke.yml`) and in the **`production` environment** (for the `deploy.yml` step). Until it's set, Tier 2 / the MCP handshake self-skip and only Tier 1 gates.

## Verification done

`scripts/mcp-smoke.mjs` ran live against prod: initialize 200 (server `career-caddy-public`), tools/list 200 (31 tools), exit 0; bogus token → exit 1; no token → skip exit 0. Workflow YAML and the Makefile target validated (parse + dry-run).

## Caveats

Post-deploy smoke is **detection, not prevention** — no auto-rollback; a red smoke means manual pin-back. Tier 3 (metabase/plane) is out of cc's repair lane and never gates.
