### PR TITLE
fix(deploy): set INSTANCE_ORIGIN on the django-q2 worker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -200,6 +200,14 @@ services:
       SCREENSHOT_DIR: /app/screenshots
       LOGFIRE_TOKEN: ${LOGFIRE_TOKEN:-}
       CAREER_CADDY_INSTANCE: ${CAREER_CADDY_INSTANCE:-careercaddy.online}
+      # Full origin used to mint ActivityPub keyId / actor / object URIs. MUST
+      # be set on the worker too: it runs the async federation dispatch
+      # (dispatch_one), and an unset value falls back to settings' localhost
+      # default, signing Create(Note) with a keyId remote instances can't
+      # dereference → HTTP-signature 401 → posts never federate. The api
+      # service sets this; the worker omitting it is why sync Accept(Follow)
+      # worked but async post fan-out silently failed. Mirror of the api line.
+      INSTANCE_ORIGIN: ${INSTANCE_ORIGIN:-http://localhost:8000}
     volumes:
       - screenshots:/app/screenshots
     depends_on:


### PR DESCRIPTION
## Problem

ActivityPub posts from `@dough@careercaddy.online` were not federating to remote followers (e.g. `@moar_powah@mstdn.social`), even though the actor resolved, the profile + outbox count rendered, and the follow was accepted (mstdn shows "Unfollow").

## Root cause

The `worker` container (django-q2 `qcluster`) was missing `INSTANCE_ORIGIN`.

ActivityPub keyId / actor / object URIs are minted from `settings.INSTANCE_ORIGIN`, which defaults to `http://localhost:8000` when the env var is absent (`api/job_hunting/settings.py`). Docker Compose only injects vars listed in a service's `environment:` block — the `worker` service had no `INSTANCE_ORIGIN` line and no `env_file`, so it ran with the localhost default.

The two delivery paths split exactly along the symptom:

| Activity | Path | Runs in | `INSTANCE_ORIGIN` | Result |
|---|---|---|---|---|
| `Accept(Follow)` | **synchronous** (`views/federation.py` `_deliver_accept`) | **api** | set | delivered → follow succeeds |
| `Create(Note)` (posts) | **async** `async_task("dispatch_one")` | **worker** | **absent → localhost** | keyId `http://localhost:8000/actors/dough#main-key` → mstdn can't dereference → HTTP-sig **401 rejected** |

Mastodon must dereference the signature `keyId` to verify it; a localhost keyId is unreachable, so every async-dispatched post was rejected. The signer, activity addressing (`to: Public`, `cc: …/followers`), and the worker deployment were all otherwise correct.

## Fix

Mirror the api service's `INSTANCE_ORIGIN` onto the `worker` service in `docker-compose.prod.yml`.

## Post-deploy notes

- Only **new** posts created after deploy will federate — Mastodon does not backfill history on follow.
- Already-`rejected` `FederationActivity` rows are terminal and won't auto-retry; their `activity_id` is deterministic (`uuid5("create:<jobpost_id>")`) so a naive re-enqueue no-ops against the dead row. Replaying the existing ~3.4K posts is a separate effort (and low-value given the no-backfill behavior above).

## Verify on the VPS

```
docker compose -f docker-compose.prod.yml exec worker python manage.py shell -c "from django.conf import settings; print(settings.INSTANCE_ORIGIN)"
docker compose -f docker-compose.prod.yml exec api    python manage.py federation_dispatch_status
```
