### PR TITLE
feat(federation): AP object-deref routing + api pin bump (BACK #93)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -248,8 +248,19 @@ services:
       # api/job_hunting/urls.py lines 135-152.
       caddy.@federation.path_0: /.well-known/webfinger
       caddy.@federation.path_1: /actors/*
+      # BACK-93: activity object ids have no human/SPA sibling — route all
+      # /activities/* to the api (same treatment as /actors/*), no Accept gate.
+      caddy.@federation.path_2: /activities/*
       caddy.handle_1: "@federation"
       caddy.handle_1.reverse_proxy: api:8000
+      # BACK-93: job-post object ids are DUAL-PURPOSE — the SPA serves the
+      # human /job-posts/<id> page; the api serves the AS2 Note at the same
+      # URI. Gate on an ActivityPub Accept header so only federation peers
+      # reach the api; browsers fall through to the SPA catch-all below.
+      caddy.@ap_objects.path: /job-posts/*
+      caddy.@ap_objects.header_regexp: Accept application/(activity|ld)\+json
+      caddy.handle_2: "@ap_objects"
+      caddy.handle_2.reverse_proxy: api:8000
       # Catch-all: SPA fallback for everything else.
       caddy.reverse_proxy: "{{upstreams 80}}"
 


### PR DESCRIPTION
## BACK #93 — make federated posts visible on remote instances

Remote instances (mstdn.social) show **zero posts** for `@dough@careercaddy.online`: the object/activity ids the outbox advertises (`/job-posts/{id}`, `/activities/{uuid}`) fell through the apex Caddy to the frontend SPA, so peers got HTML they can't ingest and dropped every post.

This is the **parent half** of the fix (api half: `overcast-software/career_caddy_api#196`, merged).

### 1. api pin bump → `c615478`
api#196 adds two AS2 root views:
- `GET /job-posts/<pk>` — content-negotiated AS2 `Note`, served only if the post is **local AND public** (private / non-local → 404 *even with* an AP `Accept` header — no leakage).
- `GET /activities/<uuid>` — replays the persisted outbound activity as AS2.

### 2. Apex Caddy routing (`docker-compose.prod.yml`, frontend labels)
```yaml
# /activities/* — no human/SPA sibling, route all to api (like /actors/*)
caddy.@federation.path_2: /activities/*
# /job-posts/* — DUAL-PURPOSE: SPA serves the human page, api serves the
# AS2 Note at the same URI. Accept-gated so only federation peers hit the api.
caddy.@ap_objects.path: /job-posts/*
caddy.@ap_objects.header_regexp: Accept application/(activity|ld)\+json
caddy.handle_2: "@ap_objects"
caddy.handle_2.reverse_proxy: api:8000
```
Strictly **additive** — `/api/*`, `/actors/*`, webfinger, and the SPA catch-all are untouched. A browser hitting `/job-posts/<id>` (no AP `Accept`) still falls through to the SPA.

### Deploy + verify
Merging triggers the Deploy workflow (rebuilds the api image + recreates the frontend container so caddy-docker-proxy reloads the labels). After deploy: re-follow `@dough@careercaddy.online` from mstdn.social (or a fresh test instance — Mastodon caches aggressively) and confirm posts render.

Closes BACK #93.
