### PR TITLE
fix(dev): frontend dev container resilient to registry DNS blips (CC-84)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,15 +160,35 @@ services:
     volumes:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules
-    # Build Tailwind once then start Ember dev server; proxy API calls to the api service
+    # Only reinstall deps when the lockfile changed (else go straight to
+    # ember serve). npm ci deletes and re-fetches node_modules on every run,
+    # so an unconditional `npm ci` wipes the frontend_node_modules volume and
+    # depends on a flawless burst of registry fetches at every boot — a single
+    # transient DNS blip (EAI_AGAIN) aborts the chain and crash-loops the
+    # container. The guard makes the persisted volume actually load-bearing;
+    # npm ci is retried once and NPM_CONFIG_FETCH_* hardens the install burst.
     command: >
-      sh -c "npm ci &&
-             npm run tailwind:build &&
-             npx ember serve --proxy http://api:8000"
+      sh -c '
+      if [ ! -f node_modules/.package-lock.json ] || [ package-lock.json -nt node_modules/.package-lock.json ]; then
+      echo "[frontend] installing deps (lockfile changed or node_modules incomplete)...";
+      npm ci || npm ci;
+      else
+      echo "[frontend] deps present and lockfile unchanged - skipping npm ci";
+      fi;
+      npm run tailwind:build &&
+      npx ember serve --proxy http://api:8000
+      '
     ports:
       - "4200:4200"
     environment:
       CHOKIDAR_USEPOLLING: "true"
+      # Harden the install burst against marginal container DNS (EAI_AGAIN).
+      NPM_CONFIG_FETCH_RETRIES: "5"
+      NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "20000"
+      NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "120000"
+      NPM_CONFIG_FETCH_TIMEOUT: "300000"
+    # A hard exit (e.g. an Ember crash) should self-recover.
+    restart: unless-stopped
     depends_on:
       - api
 


### PR DESCRIPTION
## Problem

`careercaddy.dev` (the omarchy dev frontend, fronted by pibu's caddy) was returning **502** — `career_caddy-frontend-1` was `Exited (1)` and re-exited on essentially every restart.

Diagnosed by dc-claude (diycloud side): the frontend dev service ran

```
sh -c "npm ci && npm run tailwind:build && npx ember serve --proxy http://api:8000"
```

`npm ci` **deletes and re-fetches** `node_modules` from `registry.npmjs.org` on *every* container start. node_modules is on the `frontend_node_modules` named volume, but `npm ci` wipes it each boot, so the persistence is defeated — every boot then depends on a flawless burst of hundreds of registry fetches. omarchy's container DNS is marginal (intermittent `EAI_AGAIN` resolving the registry), so a single hiccup mid-install aborts the `&&` chain → exit 1 → 502.

(The host-DNS flakiness itself is a separate diycloud-side item dc-claude is tracking; this PR's scope is making the dev frontend robust to it.)

## Fix

- **Skip the install when nothing changed.** Reinstall only when `package-lock.json` is newer than the volume's hidden lockfile (`node_modules/.package-lock.json`, written only on a *complete* install); otherwise go straight to `ember serve`. This makes the persisted volume load-bearing — a healthy volume boots in ~25s with no network.
- **Self-heal a transient blip.** Retry `npm ci` once, and raise npm's retry budget via `NPM_CONFIG_FETCH_RETRIES=5` + `NPM_CONFIG_FETCH_RETRY_*` so the install burst survives an `EAI_AGAIN`.
- **`restart: unless-stopped`** so a hard exit self-recovers.

Only `docker-compose.yml` (the local dev compose) changes. No prod (`docker-compose.prod.yml`) or CI surface is touched; merging does not trigger a prod deploy.

## Verification (live on omarchy)

The same fix was applied to the running stack via the host-local `docker-compose.override.yml` and the container force-recreated:

- guard skipped `npm ci`; ember served in ~25s
- container `running`, `restart=unless-stopped`
- `http://localhost:4200` → **200**
- `https://careercaddy.dev` (through pibu caddy) → **200** (was 502)

After this merges and the omarchy host pulls `main`, the temporary `frontend` block in that host's local `docker-compose.override.yml` should be removed — it becomes a redundant duplicate of the tracked command.

CC-84
