### PR TITLE
docs: agent auth uses Bearer header, not Api-Key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ The **AI layer** runs locally. Agents chain MCP servers as tool providers. Email
 
 **Authentication**:
 - Frontend → API: JWT (`Authorization: Bearer <token>`, 60-min lifetime, auto-refresh)
-- AI agents → API: API key (`Authorization: Api-Key <key>`, managed via `/api/v1/api-keys/`)
+- AI agents / automation → API: long-lived API key (`jh_*`) on the **same** Bearer header (`Authorization: Bearer <jh_key>`, managed via `/api/v1/api-keys/`). The API-key auth backend recognizes the `jh_` prefix — there is **no** `Api-Key` wire scheme; sending one returns 401.
 
 **Bootstrap detection**: Frontend GETs `/api/v1/healthcheck/` on every route. Response includes `bootstrap_open: true` when no users exist → routes to `/setup`. After initialization, `bootstrap_open` is always `false`.
 


### PR DESCRIPTION
## What

The Cross-Component Contracts "Authentication" section said AI agents authenticate with `Authorization: Api-Key <key>`. The api has **no** `Api-Key` wire scheme — agents and automation send their long-lived `jh_*` API key on the **same** `Authorization: Bearer` header the frontend's JWT uses (`automation/src/client/api_client.py:98`). The API-key auth backend recognizes the `jh_` prefix and routes accordingly; sending `Api-Key` returns `401 "Authentication credentials were not provided."`

## Why

This stale line has cost real time. Multiple agent/operator sessions have read it, "fixed" the cc_auto client from Bearer → Api-Key to match the doc, and broken the entire `caddy-inbox` loop (every leg 401s). Correcting the source removes the trap rather than re-litigating it each session.

## Scope

Docs only — one line in the parent `CLAUDE.md`. No code, no submodule pins, no infra. `api/CLAUDE.md` already documents Bearer correctly.
