### PR TITLE
fix(prod): cap gunicorn workers at 2 to stop api OOM-kills (CC-122)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,7 +70,16 @@ services:
       BOOTSTRAP_TOKEN: ${BOOTSTRAP_TOKEN:-}
       GUNICORN_HOST: "0.0.0.0"
       GUNICORN_PORT: "8000"
-      GUNICORN_WORKERS: "6"
+      # Keep <=2 at the 768m mem_limit below. Each gunicorn worker carries the
+      # full Django app (~124 MiB); at 6 the api idles ~765 MiB (99.6%) and the
+      # synchronous in-request LLM parse on POST /api/v1/scrapes/from-text/ tips
+      # the cgroup -> kernel OOM-kills the worker (SIGKILL / exit 137) -> caddy
+      # 502 + silent non-persist of the extension's job-post. CC-122 (2026-06-29)
+      # then recurred 2026-06-30 because a deploy reverted the racknerd-side
+      # hand-edit and re-shipped this literal "6". Do NOT re-bump for "worker
+      # headroom" without first raising mem_limit / host RAM. 2 workers x 2
+      # threads = 4 concurrent and leaves ~320 MiB for a parse.
+      GUNICORN_WORKERS: "2"
       GUNICORN_THREADS: "2"
       SA_SCHEMA_ON_POST_MIGRATE: "True"
       USE_MCP_BROWSER_AGENT: "False"


### PR DESCRIPTION
## CC-122: prod api OOM-kill on every from-text scrape

`docker-compose.prod.yml` hardcoded `GUNICORN_WORKERS: "6"`. Each gunicorn
worker carries the full Django app (~124 MiB), so 6 workers idle the
`careercaddy-api` container at ~765 MiB — 99.6% of its `mem_limit: 768m`.
The synchronous in-request LLM parse on `POST /api/v1/scrapes/from-text/`
(the browser extension's "Send this page") then tips the cgroup over the
cap and the kernel SIGKILLs a worker (exit 137) → caddy returns a 502 and
the job-post is silently not persisted.

### Why a repo fix (not just the live patch)
CC-122 was first hand-patched live on racknerd **2026-06-29** (workers → 2).
A later Deploy run reverted that hand-edit and re-shipped the repo's literal
`"6"`, so the OOM **recurred 2026-06-30**. The live stopgap is in place again,
but it's deploy-fragile until the repo carries the cap.

### The change
- `GUNICORN_WORKERS: "6"` → `"2"` (2 workers × 2 threads = 4 concurrent,
  leaves ~320 MiB headroom for a parse).
- Added a do-not-rebump comment tying the cap to the `768m` `mem_limit`.

### Scope
Single-line config change plus its comment. No `GUNICORN_THREADS`, `mem_limit`,
other services, or submodule pins touched. Merging this does **not** deploy —
a separate Deploy run ships the image + compose file.
