### PR TITLE
fix(deploy): CC-122 durable fix - async from-text (api #222) + gunicorn threads 2->4

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -70,17 +70,29 @@ services:
       BOOTSTRAP_TOKEN: ${BOOTSTRAP_TOKEN:-}
       GUNICORN_HOST: "0.0.0.0"
       GUNICORN_PORT: "8000"
-      # Keep <=2 at the 768m mem_limit below. Each gunicorn worker carries the
-      # full Django app (~124 MiB); at 6 the api idles ~765 MiB (99.6%) and the
-      # synchronous in-request LLM parse on POST /api/v1/scrapes/from-text/ tips
-      # the cgroup -> kernel OOM-kills the worker (SIGKILL / exit 137) -> caddy
-      # 502 + silent non-persist of the extension's job-post. CC-122 (2026-06-29)
-      # then recurred 2026-06-30 because a deploy reverted the racknerd-side
-      # hand-edit and re-shipped this literal "6". Do NOT re-bump for "worker
-      # headroom" without first raising mem_limit / host RAM. 2 workers x 2
-      # threads = 4 concurrent and leaves ~320 MiB for a parse.
+      # Keep WORKERS <=2 at the 768m mem_limit below. Each gunicorn worker
+      # carries the full Django app (~124 MiB); at 6 the api idled ~765 MiB
+      # (99.6%) and the synchronous in-request LLM parse on POST
+      # /api/v1/scrapes/from-text/ tipped the cgroup -> kernel OOM-kills the
+      # worker (SIGKILL / exit 137) -> caddy 502 + silent non-persist of the
+      # extension's job-post. CC-122 (2026-06-29) then recurred 2026-06-30
+      # because a deploy reverted the racknerd-side hand-edit and re-shipped a
+      # bumped WORKERS value. Do NOT re-bump WORKERS for "headroom" without
+      # first raising mem_limit / host RAM.
+      #
+      # CC-122 durable fix (api PR #222, 2026-06-30): from-text no longer parses
+      # the page synchronously in-request -- it enqueues parse_scrape_job onto
+      # the django-q2 `worker` (qcluster) below, which runs the heavy LLM parse
+      # off the gunicorn pool. So the in-request memory spike is gone and the
+      # request returns 202 in tens of ms. THREADS bumped 2 -> 4 (cheap I/O
+      # concurrency: threads share the worker's address space, NO per-thread
+      # ~124 MiB cost) to restore concurrency the worker-cap took, now that no
+      # slot holds a 10-89s LLM parse. 2 workers x 4 threads = 8 concurrent.
+      # This MATCHES the live racknerd mitigation (threads=4, recreated
+      # 2026-06-30); a deploy shipping threads=2 would revert it and re-narrow
+      # the pool. Do NOT revert THREADS to 2 without reverting async from-text.
       GUNICORN_WORKERS: "2"
-      GUNICORN_THREADS: "2"
+      GUNICORN_THREADS: "4"
       SA_SCHEMA_ON_POST_MIGRATE: "True"
       USE_MCP_BROWSER_AGENT: "False"
       CHAT_SERVICE_URL: "http://chat:8000"


### PR DESCRIPTION
## What

Durable fix for the **CC-122** prod incident: the synchronous in-request LLM parse on `POST /api/v1/scrapes/from-text/` held gunicorn worker slots for 10–89s and was the memory spike that OOM-killed the api (trivial 401s hanging 15–90s).

- **API pin bump** `ee077a5` → `2817984` (api PR #222 merge). `from_text` now enqueues `parse_scrape_job` onto the django-q2 `worker` (qcluster) instead of parsing synchronously in-request. Per-request latency drops to tens of ms (still returns `202` + `scrape_id`); the heavy LLM parse runs off the gunicorn pool on the worker. cc-api shipped #222 green (60+37 tests, ruff clean).
- **`docker-compose.prod.yml`** `GUNICORN_THREADS` 2 → 4 (`GUNICORN_WORKERS` stays 2). Matches the live racknerd mitigation already applied (api recreated with threads=4, now ~84ms). Without this, the Deploy would re-ship `threads: "2"` and revert the live hand-edit — the exact *deploy-reverts-hand-edit* class that made CC-122 recur. Threads are cheap I/O concurrency (shared address space, no per-thread ~124 MiB cost) and safe now that no slot holds a 10–89s parse. The CC-122 do-not-revert comment block was refreshed accordingly.

## Prod precondition (verified)

`careercaddy-worker` (qcluster) is Up on racknerd draining `django_q_ormq`, so enqueued from-text jobs will parse — no silent queue.

## Deploy

Merging to `main` triggers the Deploy workflow → publishes images at the new parent SHA → racknerd `up -d`. The new api/worker image carries the async from-text code; the compose ships `threads=4`.
