### PR TITLE
chore: wiki-consideration boot sequence + link deploy repo from README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,13 @@ emacsclient --eval '(claude/cc-todo-toc)'
 emacsclient --eval '(claude/cc-todo-by-state "STRT")'
 ```
 
+Consult the wiki (https://wiki.careercaddy.online) via the BookStack
+MCP `search_content` when answering "how does X work" — it is the
+canonical human-facing knowledge base. When you learn something
+durable that belongs in public docs, create/update the relevant wiki
+page (the docs analogue of storing a claudex memory). Keep it fresh as
+a per-session reflex, not a standing project.
+
 Submodule wikis (same drilldown shape, separate helper namespaces):
 
 | Submodule       | Wiki                       | Helper prefix     |

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ and `public_server` ship to prod; `browser_server` and `career_caddy_server` are
 
 ## Deployment topology
 
+> **Just want to run your own instance?** The simplest path is the standalone
+> **[career_caddy_deploy](https://github.com/overcast-software/career_caddy_deploy)** repo:
+> a one-box `docker compose up` on the published images (the job-hunt tracking loop with no
+> cloud account), plus reference Terraform (GCP/AWS) for cloud deploys. This monorepo is the
+> source; that repo is how you deploy it.
+
 The system spans two (optionally three) machines:
 
 | Target | Compose file | Services | Hardware |


### PR DESCRIPTION
Two chore commits: wire wiki-consideration into the session boot sequence, and link the standalone career_caddy_deploy self-host repo from the README Deployment topology section.