### PR TITLE
chore: retire api./mcp. subdomains in parent docs + smoke config (CC-188)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -33,11 +33,11 @@ jobs:
         working-directory: e2e
         env:
           CYPRESS_BASE_URL: https://careercaddy.online
-          CYPRESS_API_URL: https://api.careercaddy.online
-          CYPRESS_MCP_URL: https://mcp.careercaddy.online/mcp
+          CYPRESS_API_URL: https://careercaddy.online
+          CYPRESS_MCP_URL: https://careercaddy.online/mcp
           CYPRESS_CC_API_TOKEN: ${{ secrets.CC_SMOKE_API_TOKEN }}
           CC_API_TOKEN: ${{ secrets.CC_SMOKE_API_TOKEN }}
-          MCP_URL: https://mcp.careercaddy.online/mcp
+          MCP_URL: https://careercaddy.online/mcp
         run: |
           npm ci
           npm run smoke:tier1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Test: *service for everyone* → `agents/`; *operator for one user* → `automat
 Top-level peer folders advertise the heterogeneity:
 
 - `agents/agents/` — Pydantic-AI agent definitions (the spine: job_extractor, obstacle, onboarding, career_caddy CRUD)
-- `agents/mcp_servers/` — Four MCP servers; `chat_server.py` and `public_server.py` ship to prod (`:8031` chat, `:8030` public at `mcp.careercaddy.online`); `browser_server.py` and `career_caddy_server.py` are local-only
+- `agents/mcp_servers/` — Four MCP servers; `chat_server.py` and `public_server.py` ship to prod (`:8031` chat, `:8030` public, served same-origin at `careercaddy.online/mcp`); `browser_server.py` and `career_caddy_server.py` are local-only
 - `agents/browser/` — Camoufox + Playwright engine, credentials, sessions (local-only)
 - `agents/scrape_graph/` — pydantic-graph state machine for scrape + extract
 - `agents/runners/` — external workers that claim work via the api (`scrape_runner.py`, formerly `pollers/hold_poller.py`)
@@ -172,7 +172,7 @@ The **frontend** is a JSON:API client. The `application` adapter injects JWT aut
 
 The **API** uses Django ORM for all models. Startup requires only `manage.py migrate`.
 
-The **AI layer** runs locally. Agents chain MCP servers as tool providers. Email→JobPost orchestration now lives in the sibling repo `~/Projects/career_caddy_automation`, which consumes tools from `mcp.careercaddy.online/mcp`; this repo's `agents/` only ships the local browser/scrape agents and the scrape runner. The AI layer authenticates to the API using a long-lived API key (`CC_API_TOKEN`), not a JWT.
+The **AI layer** runs locally. Agents chain MCP servers as tool providers. Email→JobPost orchestration now lives in the sibling repo `~/Projects/career_caddy_automation`, which consumes tools from `careercaddy.online/mcp` (same-origin apex); this repo's `agents/` only ships the local browser/scrape agents and the scrape runner. The AI layer authenticates to the API using a long-lived API key (`CC_API_TOKEN`), not a JWT.
 
 ## Cross-Component Contracts
 

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,8 @@ smoke: ## Smoke vs prod (Tier1 always; Tier2 if CC_API_TOKEN set). Override CYPR
 		echo "e2e/ submodule not initialized — run 'git submodule update --init e2e' to enable smoke"; \
 	else \
 		base="$${CYPRESS_BASE_URL:-https://careercaddy.online}"; \
-		api="$${CYPRESS_API_URL:-https://api.careercaddy.online}"; \
-		mcp="$${MCP_URL:-https://mcp.careercaddy.online/mcp}"; \
+		api="$${CYPRESS_API_URL:-https://careercaddy.online}"; \
+		mcp="$${MCP_URL:-https://careercaddy.online/mcp}"; \
 		cd e2e && npm ci && \
 		CYPRESS_BASE_URL="$$base" CYPRESS_API_URL="$$api" CYPRESS_MCP_URL="$$mcp" npm run smoke:tier1 && \
 		if [ -n "$$CC_API_TOKEN" ]; then \

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The pieces worth a closer look:
   straight to persistence (skipping the server-side browser entirely); otherwise it falls back
   to text ingestion. Includes a staff-only tools tab gated on the server's `is_staff`.
 - **MCP-native AI layer.** Agents are `pydantic-ai` definitions wired to **Model Context
-  Protocol** servers; the public server is exposed at `mcp.careercaddy.online/mcp` for any MCP
+  Protocol** servers; the public server is exposed same-origin at `careercaddy.online/mcp` for any MCP
   client (Claude Desktop, Cursor, …). The product's own capabilities — job posts, scrapes,
   scoring, dedupe — are themselves MCP tools.
 - **SSE that survives a synchronous app server.** Long-lived event streams run on a
@@ -258,7 +258,7 @@ make help          # list every target
 | API | 8000 | 8025 |
 | Database | 5432 | 5432 |
 | Chat MCP | internal | 8031 |
-| Public MCP | — | 8030 (`mcp.careercaddy.online`) |
+| Public MCP | — | 8030 (`careercaddy.online/mcp`) |
 | Browser MCP | 3004 | — |
 
 ---


### PR DESCRIPTION
## MERGE-ORDER GATE — do not merge until CC-187 nginx `/mcp` fix is deployed

This PR repoints the smoke/deploy **`mcp`** defaults to apex `https://careercaddy.online/mcp`. Apex `/mcp` currently returns a **401 via a broken nginx redirect** (PACA **CC-187**), not a clean MCP auth challenge. The `smoke:mcp` step in the post-deploy gate (`deploy.yml`) and the `smoke.yml` cron will **fail on the `mcp` leg** until CC-187's frontend nginx fix is merged **and deployed**.

**Merge order:** land + deploy CC-187 (frontend nginx `/mcp`) → *then* merge this parent PR. Merging before CC-187 is live will red every Deploy run on the MCP smoke leg.

The **`api`** repoints are safe immediately — apex `/api` serves 200 today.

---

CC-188 (parent-only slice). `api.careercaddy.online` and `mcp.careercaddy.online` DNS were retired at the GCP cutover; the apex now serves `/api` and `/mcp` same-origin. Mapping:

- `https://api.careercaddy.online` → `https://careercaddy.online`
- `https://mcp.careercaddy.online/mcp` → `https://careercaddy.online/mcp`

## Changed (parent-owned only)

| File | Change |
|------|--------|
| `README.md` | public-MCP prose + port-map cell → apex `/mcp` |
| `CLAUDE.md` | `mcp.careercaddy.online` refs → apex same-origin `/mcp` |
| `Makefile` | `smoke` target `CYPRESS_API_URL` + `MCP_URL` defaults → apex |
| `.github/workflows/smoke.yml` | `CYPRESS_API_URL`, `CYPRESS_MCP_URL`, `MCP_URL` → apex |
| `.github/workflows/deploy.yml` | post-deploy healthcheck curl + `CYPRESS_API_URL`/`CYPRESS_MCP_URL`/`MCP_URL` → apex |

## Deliberately NOT changed — flagged for decision

**`docker-compose.prod.yml`** (`caddy:` vhost labels on the `api` and `mcp` services + `ALLOWED_HOSTS` defaults listing `api.careercaddy.online`).

This file encodes a **self-host `caddy-docker-proxy` topology** — `caddy: api.careercaddy.online` and `caddy: mcp.careercaddy.online` create separate Caddy vhosts with their own reverse-proxy upstreams. It is the self-host reference (this repo links a `career_caddy_deploy` self-host repo) where the subdomains are the *intended* deployment shape. Blindly repointing the `caddy:` labels to the apex would **break self-host routing**. Left untouched pending a deliberate decision. The `ALLOWED_HOSTS` entries are harmless (they only *permit* the host) and not urgent to trim.

## Out of scope (separate submodule PRs)

The `e2e/*` targets named in CC-188 (`tier1_api_direct.cy.js`, `tier1_mcp_challenge.cy.js`, `mcp-smoke.mjs`) live in the **`e2e/` submodule** (`career_caddy_e2e`), not parent source — they belong to that submodule's own PR (including the `tier1_api_direct` rationale rewrite and the `tier1_mcp_challenge` CC-187 assertion caveat). frontend/api/agents/automation each have their own in-flight CC-188 slices.

## Validation

Docs + smoke config only, no application code. Both workflow YAMLs parse; `make -n smoke` shows the apex defaults.
