### PR TITLE
chore: wire career_caddy_deploy as the deploy/ submodule (CC-180)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "e2e"]
 	path = e2e
 	url = git@github.com:overcast-software/career_caddy_e2e.git
+[submodule "deploy"]
+	path = deploy
+	url = git@github.com:overcast-software/career_caddy_deploy.git


### PR DESCRIPTION
## What

Wires `career_caddy_deploy` as the parent's `deploy/` submodule, pinned at `5abb494` (its `main` after PR #3 merged). This is the production IaC (GCP Cloud Run + Cloud SQL + OpenTofu) that runs `careercaddy.online`.

Part of **CC-180** (make the deploy repo authoritative) → **CC-178** (deploy submodule + racknerd→GCP CI/CD inversion).

## Why now

- deploy#3 (email SMTP wiring + Wasabi S3 backend) is merged, so `main` is authoritative — the reconciliation gate already passed (`3 add / 6 change / 0 destroy`, email-only + benign scaling, no frontend/project-number diff, 0 destroy).
- Supersedes the **untracked parent `terraform/`** working copy (Doug's local GCP config) — that dir should be decommissioned once ops move onto the submodule.

## Follow-ups (not in this PR)

- **Operational reconciliation:** the live tofu env (gitignored `terraform.tfvars`, `backend.tf`, `.terraform/` state cache) currently lives in the sibling checkout `~/Network/syncthing/Projects/career_caddy_deploy`, not this submodule. Applying from `deploy/` needs those copied over (or keep applying from the sibling for now). The in-flight **us-west1 AR migration** is mid-run from the sibling — don't disrupt it.
- Decommission the untracked parent `terraform/`.

## Gating

Parent change → **Doug-gated**. Don't merge until you're ready to pin the deploy submodule into `main`.
