### PR TITLE
fix(dagger): apply CC-161 Playwright pageError patch in the ai build

### DIFF
--- a/dagger/src/career_caddy_pipeline.py
+++ b/dagger/src/career_caddy_pipeline.py
@@ -302,6 +302,13 @@ class CareerCaddy:
             .with_workdir("/app")
             .with_directory("/app", src)
             .with_exec(["uv", "sync", "--frozen"])
+            # CC-161: mirror agents/Dockerfile:75 — guard Playwright's Firefox
+            # pageError dispatcher against a location-less error. Must run after
+            # the final `uv sync` (needs the installed bundle + scripts/), else
+            # test_installed_bundle_is_guarded fails on the Dagger-built image.
+            .with_exec(
+                ["uv", "run", "python", "scripts/patch_playwright_pageerror.py"]
+            )
         )
 
     # ── Lint-only (cheap, fail-fast) ───────────────────────────────────────


### PR DESCRIPTION
## What

Adds the CC-161 Playwright pageError-location patch step to the Dagger ai build (`_ai_base` in `dagger/src/career_caddy_pipeline.py`), mirroring `agents/Dockerfile:75`.

## Why

`dagger call test-ai` (the parent Deploy `ci` job) reconciled deps with `uv sync --frozen` but never ran `scripts/patch_playwright_pageerror.py`, so the Dagger-built ai image carried an **unguarded** Playwright bundle and `test_installed_bundle_is_guarded` failed — red parent Deploy (run 29541563004). The Dockerfile already applies the patch; this restores Dockerfile ↔ Dagger parity.

## Impact / scope

- Fixes the red `test-ai`. Pre-existing gap (surfaced when the agents pin pulled in the CC-161 patch test) — **not** introduced by the MCP/subdomain work.
- Does **not** touch prod: GCP prod deploys via `tofu`; this workflow is the racknerd/dev path.
- **CC-162** (camoufox upgrade) would eventually drop the local patch and make this step a no-op.

## Validation

Mirrors the exact Dockerfile step (idempotent + shape-matched, fails loud on bundle-shape change). Needs a CI run (`dagger call test-ai`) to confirm green.

Parent change → **Doug-gated**; don't merge until ready.
